### PR TITLE
Add releasing instructions and initial changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+## Version 1.0.5 (2019/02/27)
+
+### Issues Closed
+
+* [Issue 209](https://github.com/ssec/sift/issues/209) - Apply configured color enhancement to band images loaded after initial set
+
+In this release 1 issue were closed.
+
+### Pull Requests Merged
+
+#### Bugs fixed
+
+* [PR 16](https://github.com/ssec/sift/pull/16) - Fix presentation for newly layers not matching similar layers
+
+In this release 1 pull request was closed.
+
+
+## Version 1.0.4 (2018/12/04)
+
+
+## Version 1.0.3 (2018/11/20)
+
+
+## Version 1.0.1 (2018/10/29)
+
+
+## Version 1.0.0 (2018/10/25)
+

--- a/README.md
+++ b/README.md
@@ -54,8 +54,10 @@ variable is not set.
 
 The downloaded DMG file can be extracted opened by double clicking on it.
 The available `.app` should then be moved to the appropriate `Applications`
-folder. Double clicking the `.app` icon from `Applications` will execute
-SIFT.
+folder. Due to Apple developer application signing limitations, the `.app`
+must first be opened by right clicking and clicking "Open". After SIFT is
+opened for the first time double clicking the `.app` icon from `Applications`
+will execute SIFT as usual.
 
 ### Installing with Conda
 
@@ -71,3 +73,10 @@ And then run with:
     
 The `-h` flag can be added for documentation on additional command line
 options.
+
+### Building and releasing
+
+For instructions on how SIFT is built and packaged see the
+[releasing instructions](RELEASING.md). Note that these instructions
+are mainly for SIFT developers and may require technical understanding of
+SIFT and the libraries it depends on.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -35,3 +35,7 @@ Note that by default this will try to upload the installers and conda packages
 to the appropriate servers to be hosted or uploaded to FTP. If you do not have
 an account on these servers or do not which to upload/host the files then use
 the `--no-conda-upload` and/or `--no-installer-upload` flags.
+
+8. Create a release of the package on
+   [github](https://github.com/ssec/sift/releases) by drafting a new release
+   and copying the release notes from the changelog (see above).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,37 @@
+# Releasing SIFT
+
+1. Checkout master (`git checkout master`)
+2. Pull from repository (`git pull`)
+3. Run any necessary tests. For basic dependency checks `python sift -h`
+   should suffice.
+4. Run `loghub` and update the `CHANGELOG.md` file. If `loghub` is not
+   installed, do so by running `pip install loghub`.
+
+```bash
+loghub ssec/sift -u <username> -st v1.0.5 -plg bug "Bugs fixed" -plg enhancement "Features added" -plg documentation "Documentation changes" -plg backwards-incompatibility "Backwards incompatible changes"
+```
+
+5. Commit the change log changes.
+
+6. Create a tag with the new version number, starting with a 'v', eg:
+
+```bash
+git tag -a 1.0.5 -m "Version 1.0.5"
+```
+
+See [semver.org](http://semver.org/) on how to write a version number.
+
+6. Push changes to github `git push --follow-tags`
+7. Create conda package and installers for all supported platforms. See
+   [the wiki page](https://github.com/ssec/sift/wiki/conda-package-building#create-a-conda-package)
+   for detailed instructions on generating the conda package and other
+   special instructions. Typically this can be done with one command:
+   
+```bash
+python build_release.py
+```
+
+Note that by default this will try to upload the installers and conda packages
+to the appropriate servers to be hosted or uploaded to FTP. If you do not have
+an account on these servers or do not which to upload/host the files then use
+the `--no-conda-upload` and/or `--no-installer-upload` flags.


### PR DESCRIPTION
This PR adds the beginning of a changelog (release notes) for SIFT starting with version 1.0.5 using the `loghub` tool. It also adds basic releasing instructions to `RELEASING.md` to describe the process of creating a SIFT release.