### PR TITLE
Fix building Windows installer not cleaning up previous builds

### DIFF
--- a/build_release.py
+++ b/build_release.py
@@ -141,7 +141,8 @@ def _ssh(host, command):
 
 def _run_pyinstaller():
     log.info("Building installer...")
-    run("pyinstaller -y sift.spec".split(' '))
+    shutil.rmtree(os.path.join('dist', 'SIFT'), ignore_errors=True)
+    run("pyinstaller --clean -y sift.spec".split(' '))
 
 
 def package_installer_osx():

--- a/sift.spec
+++ b/sift.spec
@@ -6,6 +6,7 @@ from PyInstaller.utils.hooks import collect_submodules
 import vispy.glsl
 import vispy.io
 import satpy
+import distributed
 
 block_cipher = None
 exe_name = "SIFT"
@@ -16,6 +17,7 @@ data_files = [
     (os.path.dirname(vispy.glsl.__file__), os.path.join("vispy", "glsl")),
     (os.path.join(os.path.dirname(vispy.io.__file__), "_data"), os.path.join("vispy", "io", "_data")),
     (os.path.join(os.path.dirname(satpy.__file__), "etc"), os.path.join('satpy', 'etc')),
+    (os.path.join(os.path.dirname(distributed.__file__)), 'distributed'),
 ]
 
 for shape_dir in ["ne_50m_admin_0_countries", "ne_110m_admin_0_countries", "ne_50m_admin_1_states_provinces_lakes",


### PR DESCRIPTION
As one of the last releases using PyQt4, this was difficult. I ended up installing satpy which uses dask which uses dask's distributed. I had to make a small change to the spec file to include distributed's config file.

This also forces a delete of the `dist/SIFT` pyinstaller output directory before creating the `.exe`. Sometimes pyinstaller will just add new files to this, but not delete old ones. This can result in weird final `.exe`s where it gets packaged with the current environment but an older version of SIFT.