### PR TITLE
Fix conda recipe to work with imageio >2.5.0

### DIFF
--- a/conda-recipe/sift/meta.yaml
+++ b/conda-recipe/sift/meta.yaml
@@ -13,7 +13,7 @@ source:
 build:
   # If this is a new build for the same version, increment the build
   # number. If you do not include this key, it defaults to 0.
-  number: 0
+  number: 1
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
@@ -44,6 +44,7 @@ requirements:
     - netcdf4
     - h5py
     - imageio
+    - imageio-ffmpeg
     - ffmpeg
     - pillow
     - pyshp


### PR DESCRIPTION
Imageio requires another package called `imageio-ffmpeg` starting with `imageio` version 2.5.0. This PR adds that requirement to the conda recipe.