### PR TITLE
Fix additional PEP8 style issues

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,8 @@ universal=1
 max-line-length = 120
 ignore = E226,E241,E265,E266,W291,W293,W503,F999,E305,F405,W504
 exclude =
-    sift/ui
+    uwsift/ui
+    uwsift/tests/timeline.py
 
 ;[versioneer]
 ;VCS = git

--- a/uwsift/__main__.py
+++ b/uwsift/__main__.py
@@ -36,7 +36,7 @@ from vispy import app
 
 import uwsift.ui.open_cache_dialog_ui as open_cache_dialog_ui
 from uwsift import __version__
-from uwsift.common import Info, Tool, CompositeType, get_font_size
+from uwsift.common import Info, Tool, CompositeType
 from uwsift.control.doc_ws_as_timeline_scene import SiftDocumentAsFramesInTracks
 from uwsift.control.layer_tree import LayerStackTreeViewModel
 from uwsift.control.rgb_behaviors import UserModifiesRGBLayers
@@ -45,11 +45,8 @@ from uwsift.model.layer import DocRGBLayer
 from uwsift.queue import TaskQueue, TASK_PROGRESS, TASK_DOING
 # this is generated with pyuic4 pov_main.ui >pov_main_ui.py
 from uwsift.ui.pov_main_ui import Ui_MainWindow
-from uwsift.util import (WORKSPACE_DB_DIR,
-                       DOCUMENT_SETTINGS_DIR,
-                       get_package_data_dir,
-                       check_grib_definition_dir,
-                       check_imageio_deps)
+from uwsift.util import (WORKSPACE_DB_DIR, DOCUMENT_SETTINGS_DIR,
+                         get_package_data_dir, check_grib_definition_dir, check_imageio_deps)
 from uwsift.view.colormap_editor import ColormapEditor
 from uwsift.view.create_algebraic import CreateAlgebraicDialog
 from uwsift.view.export_image import ExportImageHelper
@@ -437,10 +434,8 @@ class Main(QtGui.QMainWindow):
             'GOES-16 NetCDF (*.nc *.nc4)',
         ]
         filter_str = ';;'.join(filename_filters)
-        files = QtWidgets.QFileDialog.getOpenFileNames(self,
-                                                   "Select one or more files to open",
-                                                   self._last_open_dir or os.getenv("HOME"),
-                                                   filter_str)[0]
+        files = QtWidgets.QFileDialog.getOpenFileNames(
+            self, "Select one or more files to open", self._last_open_dir or os.getenv("HOME"), filter_str)[0]
         self.open_paths(files)
 
     def _bgnd_open_paths(self, paths, uuid_list, **importer_kwargs):
@@ -869,7 +864,6 @@ class Main(QtGui.QMainWindow):
     def _init_font_sizes(self):
         # hack some font sizes until we migrate to PyQt5 and handle it better
         # was 14 on osx
-        # fsize = get_font_size(8.2)
         font = QtGui.QFont('Andale Mono')
         font.setPointSizeF(14)
         self.ui.cursorProbeLayer.setFont(font)
@@ -920,8 +914,7 @@ class Main(QtGui.QMainWindow):
         self._open_cache_dialog.activate(ordered_uuid_to_name)
 
     def open_glob(self, *args, **kwargs):
-        text, ok = QtWidgets.QInputDialog.getText(self, 'Open Glob Pattern',
-                                              'Open files matching pattern:')
+        text, ok = QtWidgets.QInputDialog.getText(self, 'Open Glob Pattern', 'Open files matching pattern:')
         from glob import glob
         if ok:
             paths = list(glob(text))

--- a/uwsift/control/layer_tree.py
+++ b/uwsift/control/layer_tree.py
@@ -42,7 +42,7 @@ from PyQt5.QtGui import QColor, QFont, QPen
 from PyQt5.QtWidgets import (QTreeView, QStyledItemDelegate, QAbstractItemView,
                              QMenu, QStyle, QStyleOptionViewItem, QActionGroup, QAction)
 
-from uwsift.common import Info, Kind, get_font_size
+from uwsift.common import Info, Kind
 from uwsift.model.document import Document
 from uwsift.view.colormap_dialogs import ChangeColormapDialog
 
@@ -73,7 +73,6 @@ class LayerWidgetDelegate(QStyledItemDelegate):
         super(LayerWidgetDelegate, self).__init__(*args, **kwargs)
         self._doc = doc
         # self._doc = doc.as_layer_stack
-        # fsize = get_font_size(7)
         self.font = QFont('Andale Mono')
         self.font.setPointSizeF(12)
 

--- a/uwsift/tests/timeline.py
+++ b/uwsift/tests/timeline.py
@@ -3,9 +3,10 @@ import sys
 import time
 from random import randint, shuffle
 
-from PyQt5.QtWidgets import *
-from PyQt5.QtCore import *  # noqa
-from PyQt5.QtGui import *  # noqa
+from PyQt5.QtWidgets import (QGraphicsScene, QMainWindow, QToolBar, QAction, QLabel, QCheckBox, QStatusBar,
+                             QGraphicsView, QGraphicsTextItem, QApplication)
+from PyQt5.QtCore import QSize, QTimer, Qt, QTimeLine, QPointF
+from PyQt5.QtGui import QKeySequence, QIcon, QFont
 from PyQt5.QtOpenGL import QGLWidget, QGLFormat, QGL
 
 
@@ -204,10 +205,11 @@ class MainWindow(QMainWindow):
             self.digits.append(t_item)
 
 
-app = QApplication(sys.argv)
+if __name__ == "__main__":
+    app = QApplication(sys.argv)
 
-scene = DemoScene()
-window = MainWindow(scene)
-window.show()
+    scene = DemoScene()
+    window = MainWindow(scene)
+    window.show()
 
-app.exec_()
+    app.exec_()

--- a/uwsift/view/colormap_editor.py
+++ b/uwsift/view/colormap_editor.py
@@ -100,8 +100,8 @@ class ColormapEditor(QtWidgets.QDialog):
             save_name = str(text)
             if save_name in self.user_colormap_states or save_name in protected_names:
                 overwrite_msg = "There is already a save with this name. Would you like to Overwrite?"
-                reply = QtWidgets.QMessageBox.question(self, 'Message',
-                                                   overwrite_msg, QtWidgets.QMessageBox.Yes, QtWidgets.QMessageBox.No)
+                reply = QtWidgets.QMessageBox.question(
+                    self, 'Message', overwrite_msg, QtWidgets.QMessageBox.Yes, QtWidgets.QMessageBox.No)
 
                 if reply == QtWidgets.QMessageBox.Yes:
                     if save_name in self.builtin_colormap_states or save_name in protected_names:
@@ -260,12 +260,12 @@ class ColormapEditor(QtWidgets.QDialog):
             QtWidgets.QMessageBox.information(self, "Error: Can not delete internal colormaps.")
             return
 
-        selected_colormaps= self.cmap_list.selectedItems()
+        selected_colormaps = self.cmap_list.selectedItems()
         to_print = ",".join([x.text() for x in selected_colormaps])
 
         delete_msg = "Please confirm you want to delete the colormap(s): " + to_print
-        reply = QtWidgets.QMessageBox.question(self, 'Message',
-                                           delete_msg, QtWidgets.QMessageBox.Yes, QtWidgets.QMessageBox.No)
+        reply = QtWidgets.QMessageBox.question(
+            self, 'Message', delete_msg, QtWidgets.QMessageBox.Yes, QtWidgets.QMessageBox.No)
         if reply == QtWidgets.QMessageBox.Yes:
             for index in selected_colormaps:
                 del self.user_colormap_states[index.text()]
@@ -274,9 +274,8 @@ class ColormapEditor(QtWidgets.QDialog):
 
     def importButtonClick(self):
         # Import colormap
-        fname = QtWidgets.QFileDialog.getOpenFileName(self, 'Get Colormap File',
-                                                  os.path.expanduser('~'),
-                                                  "Colormaps (*.json)")[0]
+        fname = QtWidgets.QFileDialog.getOpenFileName(
+            self, 'Get Colormap File', os.path.expanduser('~'), "Colormaps (*.json)")[0]
         self._import_single_file(fname)
 
     def _import_single_file(self, filename):

--- a/uwsift/view/export_image.py
+++ b/uwsift/view/export_image.py
@@ -86,11 +86,11 @@ class ExportImageDialog(QtWidgets.QDialog):
             self.ui.footerFontSizeSpinBox.setDisabled(True)
 
     def _show_file_dialog(self):
-        fn = QtWidgets.QFileDialog.getSaveFileName(self,
-                                               caption=self.tr('Screenshot Filename'),
-                                               directory=os.path.join(self._last_dir, self.default_filename),
-                                               filter=self.tr('Image Files (*.png *.jpg *.gif *.mp4 *.m4v)'),
-                                               options=QtWidgets.QFileDialog.DontConfirmOverwrite)[0]
+        fn = QtWidgets.QFileDialog.getSaveFileName(
+            self, caption=self.tr('Screenshot Filename'),
+            directory=os.path.join(self._last_dir, self.default_filename),
+            filter=self.tr('Image Files (*.png *.jpg *.gif *.mp4 *.m4v)'),
+            options=QtWidgets.QFileDialog.DontConfirmOverwrite)[0]
         if fn:
             self.ui.saveAsLineEdit.setText(fn)
         # bring this dialog back in focus

--- a/uwsift/view/open_file_wizard.py
+++ b/uwsift/view/open_file_wizard.py
@@ -21,7 +21,6 @@ from collections import OrderedDict
 
 from satpy import Scene, DatasetID
 
-from uwsift.common import get_font_size
 from uwsift.ui.open_file_wizard_ui import Ui_openFileWizard
 
 FILE_PAGE = 0
@@ -47,7 +46,6 @@ class OpenFileWizard(QtWidgets.QWizard):
         self.ui = Ui_openFileWizard()
         self.ui.setupUi(self)
 
-        # fsize = get_font_size(8.2)
         font = QtGui.QFont('Andale Mono')
         font.setPointSizeF(14)
         self.ui.productSummaryText.setFont(font)
@@ -285,10 +283,8 @@ class OpenFileWizard(QtWidgets.QWizard):
         if os.getenv("SIFT_ALLOW_ALL_READERS", ""):
             filename_filters = ['All files (*.*)'] + filename_filters
         filter_str = ';;'.join(filename_filters)
-        files = QtWidgets.QFileDialog.getOpenFileNames(self,
-                                                   "Select one or more files to open",
-                                                   self._last_open_dir or os.getenv("HOME"),
-                                                   filter_str)[0]
+        files = QtWidgets.QFileDialog.getOpenFileNames(
+            self, "Select one or more files to open", self._last_open_dir or os.getenv("HOME"), filter_str)[0]
         if not files:
             return
         self._last_open_dir = os.path.dirname(files[0])

--- a/uwsift/view/probes.py
+++ b/uwsift/view/probes.py
@@ -13,7 +13,7 @@ __author__ = 'evas'
 __docformat__ = 'reStructuredText'
 
 import logging
-from PyQt5 import QtCore, QtGui, QtWidgets
+from PyQt5 import QtWidgets
 
 import numpy as np
 from PyQt5.QtCore import QObject, pyqtSignal
@@ -31,7 +31,6 @@ from uwsift.queue import TASK_PROGRESS, TASK_DOING
 # Stuff for custom toolbars
 try:
     import six
-    from matplotlib.backends.qt_compat import QtWidgets
     import matplotlib.backends.qt_editor.figureoptions as figureoptions
 except ImportError:
     figureoptions = None

--- a/uwsift/view/scene_graph.py
+++ b/uwsift/view/scene_graph.py
@@ -46,8 +46,7 @@ from uwsift.util import get_package_data_dir
 from uwsift.view.cameras import PanZoomProbeCamera
 from uwsift.view.probes import DEFAULT_POINT_PROBE
 from uwsift.view.transform import PROJ4Transform
-from uwsift.view.visuals import (NEShapefileLines, TiledGeolocatedImage,
-                               RGBCompositeLayer, PrecomputedIsocurve)
+from uwsift.view.visuals import (NEShapefileLines, TiledGeolocatedImage, RGBCompositeLayer, PrecomputedIsocurve)
 
 LOG = logging.getLogger(__name__)
 DATA_DIR = get_package_data_dir()


### PR DESCRIPTION
Ran flake8 after sift -> uwsift name change and either the new version of `flake8` considers more things as "bad" or the search and replace for sift changed some things. This PR fixes these style issues and includes not checking the `timeline.py` test module that @rayg-ssec made. This test uses PyQt5-incompatible classes so it shouldn't be checked until it is updated/fixed.