### PR TITLE
Use WebEngine instead of building with WebKit

### DIFF
--- a/conda-recipe/uwsift/meta.yaml
+++ b/conda-recipe/uwsift/meta.yaml
@@ -50,7 +50,7 @@ requirements:
     - pyqtgraph
     - shapely
     - sqlalchemy
-    - pyqt >=5
+    - pyqt >=5.9
     - appdirs
     - pyyaml
     - quamash

--- a/setup.py
+++ b/setup.py
@@ -188,7 +188,7 @@ setup(
                       'PyOpenGL', 'netCDF4', 'h5py', 'pyproj',
                       'pyshp', 'shapely', 'rasterio', 'goesr', 'sqlalchemy',
                       'goesr', 'appdirs', 'pyyaml', 'pyqtgraph', 'satpy',
-                      'pygrib', 'imageio'
+                      'pygrib', 'imageio', 'pyqt5'
                       ],
     python_requires='>=3.6',
     extras_require=extras_require,

--- a/setup.py
+++ b/setup.py
@@ -188,7 +188,7 @@ setup(
                       'PyOpenGL', 'netCDF4', 'h5py', 'pyproj',
                       'pyshp', 'shapely', 'rasterio', 'goesr', 'sqlalchemy',
                       'goesr', 'appdirs', 'pyyaml', 'pyqtgraph', 'satpy',
-                      'pygrib', 'imageio', 'pyqt5'
+                      'pygrib', 'imageio', 'pyqt5>=5.9'
                       ],
     python_requires='>=3.6',
     extras_require=extras_require,

--- a/uwsift/ui/custom_widgets.py
+++ b/uwsift/ui/custom_widgets.py
@@ -1,4 +1,3 @@
-
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QComboBox, QSlider, QDoubleSpinBox, QWizardPage, QTableWidget, QListWidget
 from PyQt5.QtWebEngineWidgets import QWebEngineView

--- a/uwsift/ui/custom_widgets.py
+++ b/uwsift/ui/custom_widgets.py
@@ -1,7 +1,7 @@
 
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QComboBox, QSlider, QDoubleSpinBox, QWizardPage, QTableWidget, QListWidget
-from PyQt5.QtWebKitWidgets import QWebView
+from PyQt5.QtWebEngineWidgets import QWebEngineView
 
 
 class QNoScrollComboBox(QComboBox):
@@ -47,7 +47,7 @@ class QNoScrollDoubleSpinBox(QDoubleSpinBox):
             super(QNoScrollDoubleSpinBox, self).wheelEvent(ev)
 
 
-class QNoScrollWebView(QWebView):
+class QNoScrollWebView(QWebEngineView):
     def __init__(self, *args, **kwargs):
         super(QNoScrollWebView, self).__init__(*args, **kwargs)
         self.setFocusPolicy(Qt.StrongFocus)

--- a/uwsift/view/layer_details.py
+++ b/uwsift/view/layer_details.py
@@ -69,7 +69,7 @@ class SingleLayerInfoPane(QWidget):
         self.clims_text.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
         self.cmap_vis = QNoScrollWebView()
         self.cmap_vis.setFixedSize(min_width, 30)
-        self.cmap_vis.page().mainFrame().setScrollBarPolicy(Qt.Vertical, Qt.ScrollBarAlwaysOff)
+        self.cmap_vis.page().runJavaScript('document.body.style.overflow = "hidden";')
         self.composite_details = QLabel("Composite Details")
         self.composite_details.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
         f = QFont()


### PR DESCRIPTION
Closes #233.

This allows the newest version of PyQt5 to be used with SIFT.