### PR TITLE
Remove unnecessary band metadata

### DIFF
--- a/uwsift/common.py
+++ b/uwsift/common.py
@@ -275,7 +275,6 @@ class Info(Enum):
 
     # instrument and scene information
     PLATFORM = 'platform'  # full standard name of spacecraft
-    BAND = 'band'  # band number (multispectral instruments)
     SCENE = 'scene'  # standard scene identifier string for instrument, e.g. FLDK
     INSTRUMENT = 'instrument'  # Instrument enumeration, or string with full standard name
 

--- a/uwsift/model/document.py
+++ b/uwsift/model/document.py
@@ -1647,34 +1647,6 @@ class Document(QObject):  # base class is rightmost, mixins left of that
         LOG.debug("sorted products: {}".format(repr(zult)))
         return [u for u, _ in zult]
 
-    # def sort_datasets_into_load_order(self, infos):
-    #     """
-    #     given a list of paths, sort them into order, assuming layers are added at top of layer list
-    #     first: unknown paths
-    #     outer order: descending band number
-    #     inner order: descending time step
-    #     :param infos: iterable of info dictionaries
-    #     :return: ordered list of path strings
-    #     """
-    #
-    #     # FIXME: It is not possible for a pathname to be considered "irrelevant"
-    #     # riffraff = [path for path in paths if not nfo[path]]
-    #     riffraff = []
-    #     # ahi = [nfo[path] for path in paths if nfo[path]]
-    #     # names = [path for path in paths if nfo[path]]
-    #     # bands = [x.get(Info.BAND, None) for x in ahi]
-    #     # times = [x.get(Info.SCHED_TIME, None) for x in ahi]
-    #     # order = [(band, time, path) for band,time,path in zip(bands,times,names)]
-    #
-    #     def _sort_key(info):
-    #         return (info.get(Info.DATASET_NAME),
-    #                 info.get(Info.OBS_TIME),
-    #                 info.get(Info.PATHNAME))
-    #     order = sorted(infos, key=_sort_key, reverse=True)
-    #     paths = riffraff + [info.get(Info.PATHNAME) for info in order]
-    #     LOG.debug(paths)
-    #     return paths
-
     def time_label_for_uuid(self, uuid):
         """used to update animation display when a new frame is shown
         """
@@ -2005,7 +1977,7 @@ class Document(QObject):  # base class is rightmost, mixins left of that
                     nfo[uuid] = name
         self.didChangeColormap.emit(nfo)
 
-    def current_layers_where(self, kinds=None, bands=None, uuids=None,
+    def current_layers_where(self, kinds=None, uuids=None,
                              dataset_names=None, wavelengths=None, colormaps=None):
         """check current layer list for criteria and yield"""
         L = self.current_layer_set
@@ -2014,8 +1986,6 @@ class Document(QObject):  # base class is rightmost, mixins left of that
                 continue
             layer = self._layer_with_uuid[p.uuid]
             if (kinds is not None) and (layer.kind not in kinds):
-                continue
-            if (bands is not None) and (layer[Info.BAND] not in bands):
                 continue
             if (dataset_names is not None) and (layer[Info.DATASET_NAME] not in dataset_names):
                 continue

--- a/uwsift/model/layer.py
+++ b/uwsift/model/layer.py
@@ -97,10 +97,6 @@ class DocLayer(ChainMap):
         return self[Info.KIND]
 
     @property
-    def band(self):
-        return self.get(Info.BAND)
-
-    @property
     def instrument(self):
         return self.get(Info.INSTRUMENT)
 
@@ -277,11 +273,6 @@ class DocRGBLayer(DocCompositeLayer):
         return False
 
     @property
-    def band(self):
-        gb = self._get_if_not_none_func(attr='band')
-        return gb(self.r), gb(self.g), gb(self.b)
-
-    @property
     def central_wavelength(self):
         gb = self._get_if_not_none_func(item=Info.CENTRAL_WAVELENGTH)
         return gb(self.r), gb(self.g), gb(self.b)
@@ -383,7 +374,6 @@ class DocRGBLayer(DocCompositeLayer):
             Info.DISPLAY_NAME: name,
             Info.DISPLAY_TIME: display_time,
             Info.SCHED_TIME: self.sched_time,
-            Info.BAND: self.band,
             Info.CENTRAL_WAVELENGTH: self.central_wavelength,
             Info.INSTRUMENT: self.instrument,
             Info.PLATFORM: self.platform,

--- a/uwsift/view/layer_details.py
+++ b/uwsift/view/layer_details.py
@@ -42,7 +42,6 @@ class SingleLayerInfoPane(QWidget):
     name_text = None
     time_text = None
     instrument_text = None
-    band_text = None
     colormap_text = None
     clims_text = None
 
@@ -59,8 +58,6 @@ class SingleLayerInfoPane(QWidget):
         self.time_text.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
         self.instrument_text = QLabel("")
         self.instrument_text.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
-        self.band_text = QLabel("")
-        self.band_text.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
         self.wavelength_text = QLabel("")
         self.wavelength_text.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
         self.colormap_text = QLabel("")
@@ -88,13 +85,12 @@ class SingleLayerInfoPane(QWidget):
         layout.addWidget(self.name_text, 0, 0)
         layout.addWidget(self.time_text, 1, 0)
         layout.addWidget(self.instrument_text, 2, 0)
-        layout.addWidget(self.band_text, 3, 0)
-        layout.addWidget(self.wavelength_text, 4, 0)
-        layout.addWidget(self.colormap_text, 5, 0)
-        layout.addWidget(self.clims_text, 6, 0)
-        layout.addWidget(self.cmap_vis, 7, 0)
-        layout.addWidget(self.composite_details, 8, 0)
-        layout.addWidget(self.composite_codeblock, 9, 0)
+        layout.addWidget(self.wavelength_text, 3, 0)
+        layout.addWidget(self.colormap_text, 4, 0)
+        layout.addWidget(self.clims_text, 5, 0)
+        layout.addWidget(self.cmap_vis, 6, 0)
+        layout.addWidget(self.composite_details, 7, 0)
+        layout.addWidget(self.composite_codeblock, 8, 0)
         self.setLayout(layout)
 
         # add this widget to the scrollable parent widget
@@ -109,7 +105,6 @@ class SingleLayerInfoPane(QWidget):
         self.name_text.setText("Name: " + shared_info[Info.DISPLAY_NAME])
         self.time_text.setText("Time: " + shared_info[Info.DISPLAY_TIME])
         self.instrument_text.setText("Instrument: " + shared_info[Info.INSTRUMENT])
-        self.band_text.setText("Band: " + shared_info[Info.BAND])
         self.wavelength_text.setText("Wavelength: " + shared_info[Info.CENTRAL_WAVELENGTH])
         self.colormap_text.setText("Colormap: " + (shared_info["colormap"] or ""))
         self.clims_text.setText("Color Limits: " + shared_info["climits"])
@@ -233,17 +228,6 @@ class SingleLayerInfoPane(QWidget):
             self._update_if_different(shared_info, this_prez, attr='colormap')
             self._get_shared_color_limits(shared_info, layer_info, this_prez)
             self._get_code_block(shared_info, layer_uuid)
-
-            # band
-            new_band = layer_info.get(Info.BAND)
-            if isinstance(new_band, (tuple, list)):
-                new_band = "(" + ", ".join([str(x) if x is not None else '---' for x in new_band]) + ")"
-            else:
-                new_band = str(new_band) if new_band is not None else '---'
-            if Info.BAND not in shared_info:
-                shared_info[Info.BAND] = new_band
-            else:
-                shared_info[Info.BAND] = "---" if shared_info[Info.BAND] != new_band else new_band
 
             # wavelength
             wl = layer_info.get(Info.CENTRAL_WAVELENGTH)

--- a/uwsift/workspace/guidebook.py
+++ b/uwsift/workspace/guidebook.py
@@ -169,9 +169,6 @@ class ABI_AHI_Guidebook(Guidebook):
     "e.g. HS_H08_20150714_0030_B10_FLDK_R20.merc.tif"
     _cache = None  # {uuid:metadata-dictionary, ...}
 
-    REFL_BANDS = [1, 2, 3, 4, 5, 6]
-    BT_BANDS = [7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
-
     def __init__(self):
         self._cache = {}
 
@@ -185,18 +182,7 @@ class ABI_AHI_Guidebook(Guidebook):
         """
         z = {}
 
-        if info[Info.KIND] in (Kind.IMAGE, Kind.COMPOSITE):
-            if info.get(Info.CENTRAL_WAVELENGTH) is None:
-                try:
-                    wl = NOMINAL_WAVELENGTHS[info[Info.PLATFORM]][info[Info.INSTRUMENT]][info[Info.BAND]]
-                except KeyError:
-                    wl = None
-                z[Info.CENTRAL_WAVELENGTH] = wl
-
-        if Info.BAND in info:
-            band_short_name = "B{:02d}".format(info[Info.BAND])
-        else:
-            band_short_name = info.get(Info.DATASET_NAME, '???')
+        band_short_name = info.get(Info.DATASET_NAME, '???')
         if Info.SHORT_NAME not in info:
             z[Info.SHORT_NAME] = band_short_name
         else:
@@ -204,31 +190,18 @@ class ABI_AHI_Guidebook(Guidebook):
         if Info.LONG_NAME not in info:
             z[Info.LONG_NAME] = info.get(Info.SHORT_NAME, z[Info.SHORT_NAME])
 
-        if Info.STANDARD_NAME not in info:
-            try:
-                z[Info.STANDARD_NAME] = STANDARD_NAMES[info[Info.PLATFORM]][info[Info.INSTRUMENT]][info[Info.BAND]]
-            except KeyError:
-                z[Info.STANDARD_NAME] = "." + str(z.get(Info.SHORT_NAME))
-
-        # Only needed for backwards compatibility with originally supported geotiffs
-        if not info.get(Info.UNITS):
-            standard_name = info.get(Info.STANDARD_NAME, z.get(Info.STANDARD_NAME))
-            if standard_name == 'toa_bidirectional_reflectance':
-                z[Info.UNITS] = '1'
-            elif standard_name == 'toa_brightness_temperature':
-                z[Info.UNITS] = 'kelvin'
+        z.setdefault(info.get(Info.STANDARD_NAME, 'unknown'))
         if info.get(Info.UNITS, z.get(Info.UNITS)) in ['K', 'Kelvin']:
             z[Info.UNITS] = 'kelvin'
 
         return z
 
     def _is_refl(self, dsi):
-        # work around for old `if band in BAND_TYPE`
-        return dsi.get(Info.BAND) in self.REFL_BANDS or dsi.get(Info.STANDARD_NAME) == "toa_bidirectional_reflectance"
+        return dsi.get(Info.STANDARD_NAME) == "toa_bidirectional_reflectance"
 
     def _is_bt(self, dsi):
-        return dsi.get(Info.BAND) in self.BT_BANDS or \
-            dsi.get(Info.STANDARD_NAME) in ["toa_brightness_temperature", 'brightness_temperature', 'air_temperature']
+        return dsi.get(Info.STANDARD_NAME) in \
+               ["toa_brightness_temperature", 'brightness_temperature', 'air_temperature']
 
     def climits(self, dsi):
         # Valid min and max for colormap use for data values in file (unconverted)

--- a/uwsift/workspace/guidebook.py
+++ b/uwsift/workspace/guidebook.py
@@ -164,6 +164,8 @@ STANDARD_NAMES = {
     Platform.GOES_17: _SN_GOESR_ABI,
 }
 
+BT_STANDARD_NAMES = ["toa_brightness_temperature", 'brightness_temperature', 'air_temperature']
+
 
 class ABI_AHI_Guidebook(Guidebook):
     "e.g. HS_H08_20150714_0030_B10_FLDK_R20.merc.tif"
@@ -200,8 +202,7 @@ class ABI_AHI_Guidebook(Guidebook):
         return dsi.get(Info.STANDARD_NAME) == "toa_bidirectional_reflectance"
 
     def _is_bt(self, dsi):
-        return dsi.get(Info.STANDARD_NAME) in \
-               ["toa_brightness_temperature", 'brightness_temperature', 'air_temperature']
+        return dsi.get(Info.STANDARD_NAME) in BT_STANDARD_NAMES
 
     def climits(self, dsi):
         # Valid min and max for colormap use for data values in file (unconverted)

--- a/uwsift/workspace/importer.py
+++ b/uwsift/workspace/importer.py
@@ -1037,7 +1037,6 @@ class SatpyImporter(aImporter):
             model_time = ds.attrs.get('model_time')
             if model_time is not None:
                 ds.attrs[Info.DATASET_NAME] += " " + model_time.isoformat()
-            ds.attrs[Info.BAND] = 0
             ds.attrs[Info.SHORT_NAME] = ds.attrs['name']
             if ds.attrs.get('level') is not None:
                 ds.attrs[Info.SHORT_NAME] = "{} @ {}hPa".format(

--- a/uwsift/workspace/workspace.py
+++ b/uwsift/workspace/workspace.py
@@ -447,12 +447,9 @@ class Workspace(QObject):
 
     def _migrate_metadata(self):
         """Replace legacy metadata uses with new uses."""
-        with self._inventory as s:
-            for p in s.query(Product).all():
-                # NOTE: Can be remove after 0.9.x releases are done (0.10.x or 1.0)
-                if os.path.splitext(p.info[Info.DATASET_NAME])[1] and p.info[Info.BAND]:
-                    LOG.info("rewriting DATASET_NAME to new style using band: {}".format(repr(p)))
-                    p.update({Info.DATASET_NAME: 'B{:02d}'.format(p.info[Info.BAND])})
+        # with self._inventory as s:
+        #     for p in s.query(Product).all():
+        #         pass
 
     def _bgnd_startup_purge(self):
         ntot = 5


### PR DESCRIPTION
As SIFT evolves and depends on Satpy more, we no longer have easy access to the band **number** of a specific data variable. Typically what band a variable is is part of the name ("B01", "C01", etc) of that variable. Additionally, the band number is currently used in some metadata (guidebook) operations like "what CF standard_name is this band?" which is unreliable once we support satellites beyond ABI/AHI. Overall, guidebook things should be moved to Satpy as much as possible or should be configurable by the user (once donfig is available).