### PR TITLE
Fix vertex coordinates being calculated incorrectly

### DIFF
--- a/uwsift/view/tile_calculator.py
+++ b/uwsift/view/tile_calculator.py
@@ -616,7 +616,7 @@ class TileCalculator(object):
                                         offset_rez.dy, offset_rez.dx, tessellation_level,
                                         self.pixel_rez.dx, self.pixel_rez.dy,
                                         self.tile_shape.y, self.tile_shape.x,
-                                        self.image_center.y, self.image_shape.x, quads)
+                                        self.image_center.y, self.image_center.x, quads)
         quads = quads.reshape(tessellation_level * tessellation_level * 6, 3)
         return quads[:, :2]
 


### PR DESCRIPTION
Closes #252 (thanks @gerritholl)

This was a small typo introduced during #237. The calculations to get the vertex coordinates were using the wrong number for the X coordinate of the left-most pixel. Kind of throws off where the data ends up. :sweat_smile: 

@katherinekolman You should consider this another area that should get some unit tests if/when you have the time.