### PR TITLE
Remove unused scipy dependency and add scikit-image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,10 @@ matrix:
   - env: PYTHON_VERSION=3.7
     os: osx
     language: generic
-  - env: PYTHON_VERSION=3.7
+  - env:
+    - PYTHON_VERSION=3.7
+    # See https://github.com/conda-forge/scipy-feedstock/issues/120
+    - CONDA_CHANNEL_PRIORITY='flexible'
     os: windows
     language: shell
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ matrix:
     language: generic
   - env:
     - PYTHON_VERSION=3.7
+      # See https://github.com/conda-forge/scipy-feedstock/issues/120
+    - CONDA_CHANNEL_PRIORITY='flexible'
     os: windows
     language: shell
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
   - PYTHON_VERSION=$TRAVIS_PYTHON_VERSION
   - NUMPY_VERSION=stable
   - MAIN_CMD='python setup.py'
-  - CONDA_DEPENDENCIES='hdf5 rasterio matplotlib numba pyproj coveralls pytest pytest-mock pytest-cov pytest-qt vispy pyopengl netcdf4 h5py imageio imageio-ffmpeg ffmpeg pillow pyshp pyqtgraph shapely sqlalchemy pyqt appdirs pyyaml satpy eccodes'
+  - CONDA_DEPENDENCIES='hdf5 rasterio matplotlib numba pyproj coveralls pytest pytest-mock pytest-cov pytest-qt vispy pyopengl netcdf4 h5py imageio imageio-ffmpeg ffmpeg pillow pyshp pyqtgraph shapely sqlalchemy pyqt appdirs pyyaml satpy eccodes scikit-image'
   - PIP_DEPENDENCIES='pytest-xvfb'
   - SETUP_XVFB=True
   - EVENT_TYPE='push pull_request'
@@ -21,8 +21,6 @@ matrix:
     language: generic
   - env:
     - PYTHON_VERSION=3.7
-    # See https://github.com/conda-forge/scipy-feedstock/issues/120
-    - CONDA_CHANNEL_PRIORITY='flexible'
     os: windows
     language: shell
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
   - PYTHON_VERSION=$TRAVIS_PYTHON_VERSION
   - NUMPY_VERSION=stable
   - MAIN_CMD='python setup.py'
-  - CONDA_DEPENDENCIES='hdf5 rasterio matplotlib scipy numba pyproj coveralls pytest pytest-mock pytest-cov pytest-qt vispy pyopengl netcdf4 h5py imageio imageio-ffmpeg ffmpeg pillow pyshp pyqtgraph shapely sqlalchemy pyqt appdirs pyyaml satpy eccodes'
+  - CONDA_DEPENDENCIES='hdf5 rasterio matplotlib numba pyproj coveralls pytest pytest-mock pytest-cov pytest-qt vispy pyopengl netcdf4 h5py imageio imageio-ffmpeg ffmpeg pillow pyshp pyqtgraph shapely sqlalchemy pyqt appdirs pyyaml satpy eccodes'
   - PIP_DEPENDENCIES='pytest-xvfb'
   - SETUP_XVFB=True
   - EVENT_TYPE='push pull_request'

--- a/conda-recipe/uwsift/meta.yaml
+++ b/conda-recipe/uwsift/meta.yaml
@@ -34,7 +34,6 @@ requirements:
     - hdf5
     - rasterio
     - matplotlib
-    - scipy
     - numba >=0.30
     - pyproj >=1.9.4
     - vispy >=0.6.0.dev1
@@ -55,6 +54,7 @@ requirements:
     - pyyaml
     - satpy >=0.10.0a0
     - pygrib  # [not win]
+    - scikit-image
 
 test:
   commands:

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -48,11 +48,6 @@ extensions = [
     'sphinxcontrib.blockdiag',
 ]
 
-# install_requires=['numpy', 'pillow', 'scipy', 'numba', 'vispy>=0.6.0',
-#                   'PyOpenGL', 'netCDF4', 'h5py', 'pyproj',
-#                   'pyshp', 'shapely', 'rasterio', 'goesr', 'sqlalchemy',
-#                   'goesr', 'appdirs', 'pyyaml', 'pyqtgraph', 'satpy',
-#                   'pygrib', 'imageio'
 autodoc_mock_imports = [
     'netCDF4', 'h5py', 'pyshp', 'shapely', 'rasterio', 'goesr',
     'pyqtgraph', 'satpy', 'pygrib', 'imageio']

--- a/rtd_requirements.txt
+++ b/rtd_requirements.txt
@@ -3,7 +3,6 @@ sphinxcontrib-seqdiag
 sphinxcontrib-blockdiag
 sphinx_rtd_theme
 numpy
-scipy
 pillow
 pyproj
 sqlalchemy

--- a/setup.py
+++ b/setup.py
@@ -189,10 +189,11 @@ setup(
                  "Topic :: Scientific/Engineering"],
     zip_safe=False,
     include_package_data=True,
-    install_requires=['numpy', 'pillow', 'scipy', 'numba', 'vispy>=0.6.0',
+    install_requires=['numpy', 'pillow', 'numba', 'vispy>=0.6.0',
                       'PyOpenGL', 'netCDF4', 'h5py', 'pyproj',
                       'pyshp', 'shapely', 'rasterio', 'sqlalchemy',
                       'appdirs', 'pyyaml', 'pyqtgraph', 'satpy', 'matplotlib',
+                      'scikit-image',
                       'pygrib;sys_platform=="linux" or sys_platform=="darwin"', 'imageio', 'pyqt5>=5.9'
                       ],
     python_requires='>=3.6',


### PR DESCRIPTION
As mentioned in #258, there is a current build limitation with scipy that makes conda environments on Windows unsolvable. I also noticed that scikit-image wasn't being added although we'd like to use it with Vispy's IsoCurveVisual.