### PR TITLE
Remove flexible channel priority for Windows travis environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,7 @@ matrix:
   - env: PYTHON_VERSION=3.7
     os: osx
     language: generic
-  - env:
-    - PYTHON_VERSION=3.7
-    # See https://github.com/conda-forge/scipy-feedstock/issues/120
-    - CONDA_CHANNEL_PRIORITY='flexible'
+  - env: PYTHON_VERSION=3.7
     os: windows
     language: shell
 install:


### PR DESCRIPTION
This should be fixed on conda-forge now.