### PR TITLE
Fix incorrect wavelength being taken from Satpy

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/ssec/sift/badge.svg)](https://coveralls.io/github/ssec/sift)
 [![PyPI version](https://badge.fury.io/py/uwsift.svg)](https://badge.fury.io/py/uwsift)
 [![Build Status](https://travis-ci.org/ssec/sift.svg?branch=master)](https://travis-ci.org/ssec/sift)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.2587908.svg)](https://doi.org/10.5281/zenodo.2587908)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.2587907.svg)](https://doi.org/10.5281/zenodo.2587907)
 [![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/gitterHQ/gitter)
 
 

--- a/uwsift/tests/workspace/test_importer.py
+++ b/uwsift/tests/workspace/test_importer.py
@@ -119,4 +119,3 @@ def test_satpy_importer_basic(tmpdir, monkeypatch, mocker):
     products = list(imp.merge_products())
     assert len(products) == 1
     assert products[0].info[Info.CENTRAL_WAVELENGTH] == 2.0
-

--- a/uwsift/tests/workspace/test_importer.py
+++ b/uwsift/tests/workspace/test_importer.py
@@ -4,7 +4,14 @@
 
 import os
 import yaml
-from uwsift.workspace.importer import available_satpy_readers
+import xarray as xr
+import numpy as np
+import dask.array as da
+from datetime import datetime
+from satpy import DatasetID, Scene
+from pyresample.geometry import AreaDefinition
+from uwsift.workspace.importer import available_satpy_readers, SatpyImporter
+from uwsift.common import Info
 
 
 def test_available_satpy_readers_defaults():
@@ -69,3 +76,47 @@ def test_available_satpy_readers_known_cache(tmpdir, monkeypatch):
     assert isinstance(readers, list)
     assert len(readers) != 0
     assert isinstance(readers[0], str)
+
+
+def _get_data_array_generator(data_arrs):
+    """Help mimic what a real Satpy Scene would do."""
+    yield from data_arrs
+
+
+def test_satpy_importer_basic(tmpdir, monkeypatch, mocker):
+    """Basic import test using Satpy."""
+    db_sess = mocker.MagicMock()
+    attrs = {
+        'name': 'C01',
+        'wavelength': (1.0, 2.0, 3.0),
+        'area': AreaDefinition(
+            'test', 'test', 'test',
+            {
+                'proj': 'geos',
+                'sweep': 'x',
+                'lon_0': -75,
+                'h': 35786023,
+                'ellps': 'GRS80',
+                'units': 'm',
+            }, 5, 5,
+            (-5434894.885056, -5434894.885056, 5434894.885056, 5434894.885056)
+        ),
+        'start_time': datetime(2018, 9, 10, 17, 0, 31, 100000),
+        'end_time': datetime(2018, 9, 10, 17, 11, 7, 800000),
+    }
+    data_arr = xr.DataArray(da.from_array(np.empty((5, 5), dtype=np.float64), chunks='auto'),
+                            attrs=attrs)
+    scn = Scene()
+    scn['C01'] = data_arr
+    scn.load = mocker.MagicMock()  # don't do anything on load
+
+    imp = SatpyImporter(['/test/file.nc'], tmpdir, db_sess,
+                        scene=scn,
+                        reader='abi_l1b',
+                        dataset_ids=[DatasetID(name='C01')])
+    imp.merge_resources()
+    assert imp.num_products == 1
+    products = list(imp.merge_products())
+    assert len(products) == 1
+    assert products[0].info[Info.CENTRAL_WAVELENGTH] == 2.0
+

--- a/uwsift/workspace/importer.py
+++ b/uwsift/workspace/importer.py
@@ -1070,7 +1070,7 @@ class SatpyImporter(aImporter):
             ds.attrs.setdefault(Info.STANDARD_NAME, ds.attrs.get('standard_name'))
             if 'wavelength' in ds.attrs:
                 ds.attrs.setdefault(Info.CENTRAL_WAVELENGTH,
-                                    ds.attrs['wavelength'][0])
+                                    ds.attrs['wavelength'][1])
 
             # Resolve anything else needed by SIFT
             id_str = ":".join(str(v) for v in DatasetID.from_dict(ds.attrs))


### PR DESCRIPTION
Closes #267 

Satpy uses three wavelength numbers (minimum, nominal, maximum) based on documented bandwidths of every channel for an instrument. I accidentally was taking the minimum value and assigning it to SIFT's "CENTRAL_WAVELENGTH". This PR fixes this.

This should really get tests, but I'll have to do that later.