### PR TITLE
Fix grib reader not being included in available readers by default

### DIFF
--- a/uwsift/__init__.py
+++ b/uwsift/__init__.py
@@ -28,6 +28,7 @@ DEFAULT_CONFIGURATION = {
             'ami_l1b',
             'fci_l1c_fdhsi',
             'glm_l2',
+            'grib',
             'li_l2',
             'seviri_l1b_hrit',
             'seviri_l1b_native',


### PR DESCRIPTION
I forgot to add the 'grib' reader to the list of readers to use.