### PR TITLE
Fix open file wizard when resolution is a floating point number

### DIFF
--- a/uwsift/__main__.py
+++ b/uwsift/__main__.py
@@ -20,7 +20,6 @@ REQUIRES
 
 __author__ = 'rayg'
 
-import asyncio
 import logging
 import os
 import sys

--- a/uwsift/__main__.py
+++ b/uwsift/__main__.py
@@ -694,6 +694,7 @@ class Main(QtGui.QMainWindow):
                                                center=center,
                                                parent=self)
         self.export_image = ExportImageHelper(self, self.document, self.scene_manager)
+        self._wizard_dialog = None
 
         self._init_layer_panes()
         self._init_rgb_pane()
@@ -922,6 +923,7 @@ class Main(QtGui.QMainWindow):
     def open_wizard(self, *args, **kwargs):
         from uwsift.view.open_file_wizard import OpenFileWizard
         wizard_dialog = OpenFileWizard(base_dir=self._last_open_dir, parent=self)
+        self._wizard_dialog = wizard_dialog
         if wizard_dialog.exec_():
             LOG.info("Loading products from open wizard...")
             scenes = wizard_dialog.scenes
@@ -936,6 +938,7 @@ class Main(QtGui.QMainWindow):
                             **importer_kwargs)
         else:
             LOG.debug("Wizard closed, nothing to load")
+        self._wizard_dialog = None
 
     def remove_region_polygon(self, action: QtGui.QAction = None, *args):
         if self.scene_manager.has_pending_polygon():

--- a/uwsift/common.py
+++ b/uwsift/common.py
@@ -22,11 +22,6 @@ from enum import Enum
 from typing import MutableSequence, Tuple, Optional, Iterable, Any, NamedTuple
 from uuid import UUID
 
-import numpy as np
-
-__author__ = 'rayg'
-__docformat__ = 'reStructuredText'
-
 import os
 import sys
 from datetime import datetime, timedelta

--- a/uwsift/tests/view/test_open_file_wizard.py
+++ b/uwsift/tests/view/test_open_file_wizard.py
@@ -83,8 +83,8 @@ def test_wizard_abi_l1b(qtbot, monkeypatch):
     # Add a single file (see mock above)
     qtbot.mouseClick(wiz.ui.addButton, Qt.LeftButton)
     # Adding this file for the 'abi_l1b' should make this page complete
-    print(dir(QWizard.WizardButton))
-    assert wiz.button(QWizard.WizardButton.NextButton).isEnabled()
+    # HACK: Bug in Windows, no enum's by name
+    assert wiz.button(getattr(QWizard.WizardButton, 'NextButton', 1)).isEnabled()
     # Go to the next page
     wiz.next()
 
@@ -95,7 +95,8 @@ def test_wizard_abi_l1b(qtbot, monkeypatch):
         item = wiz.ui.selectIDTable.item(row_idx, 0)
         assert item.checkState() == Qt.Checked
     # A product is selected, that should be to good for the next page
-    assert wiz.button(QWizard.WizardButton.FinishButton).isEnabled()
+    # HACK: Bug in Windows, no enum's by name
+    assert wiz.button(getattr(QWizard.WizardButton, 'FinishButton', 1)).isEnabled()
     # Go to the next page
     wiz.next()
 

--- a/uwsift/tests/view/test_open_file_wizard.py
+++ b/uwsift/tests/view/test_open_file_wizard.py
@@ -17,6 +17,7 @@
 """Test various parts of the Open File Wizard dialog."""
 
 from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import QWizard
 from uwsift.view.open_file_wizard import OpenFileWizard
 
 
@@ -82,7 +83,8 @@ def test_wizard_abi_l1b(qtbot, monkeypatch):
     # Add a single file (see mock above)
     qtbot.mouseClick(wiz.ui.addButton, Qt.LeftButton)
     # Adding this file for the 'abi_l1b' should make this page complete
-    assert wiz.button(wiz.WizardButton.NextButton).isEnabled()
+    print(dir(QWizard.WizardButton))
+    assert wiz.button(QWizard.WizardButton.NextButton).isEnabled()
     # Go to the next page
     wiz.next()
 
@@ -93,7 +95,7 @@ def test_wizard_abi_l1b(qtbot, monkeypatch):
         item = wiz.ui.selectIDTable.item(row_idx, 0)
         assert item.checkState() == Qt.Checked
     # A product is selected, that should be to good for the next page
-    assert wiz.button(wiz.WizardButton.FinishButton).isEnabled()
+    assert wiz.button(QWizard.WizardButton.FinishButton).isEnabled()
     # Go to the next page
     wiz.next()
 

--- a/uwsift/tests/view/test_open_file_wizard.py
+++ b/uwsift/tests/view/test_open_file_wizard.py
@@ -133,4 +133,3 @@ def test_wizard_abi_l1b(qtbot, monkeypatch):
     assert len(wiz.scenes) == 1
     sel_ids = wiz.collect_selected_ids()
     assert len(sel_ids) == 1
-

--- a/uwsift/tests/view/test_open_file_wizard.py
+++ b/uwsift/tests/view/test_open_file_wizard.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# This file is part of SIFT.
+#
+# SIFT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# SIFT is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with SIFT.  If not, see <http://www.gnu.org/licenses/>.
+"""Test various parts of the Open File Wizard dialog."""
+
+from PyQt5.QtCore import Qt, QTimer
+from PyQt5 import QtWidgets
+from uwsift.view.open_file_wizard import OpenFileWizard
+from functools import partial
+
+
+def get_wizard_object(window):
+    """Wait until the OpenFileWizard dialog is available and return a reference."""
+    wiz = window.findChildren(OpenFileWizard)
+    while len(wiz) < 1:
+        # force Qt event loop to process events until our dialog is shown
+        QtWidgets.QApplication.processEvents()
+    assert len(wiz) == 1
+    return wiz[0]
+
+
+def need_wizard_test(func, *args):
+    """Decorator used to simplify tests between the main window and wizard."""
+    def new_func(qtbot, window):
+        """Wrap decorated function to simplify getting the wizard object."""
+        def check_dialog():
+            """Keep checking that the wizard is closed until it is closed."""
+            wiz = window.findChildren(OpenFileWizard)
+            # make sure it is closed and deleted
+            assert len(wiz) == 0
+
+        qtbot.addWidget(window)
+        QTimer.singleShot(0, partial(func, qtbot, window))
+        qtbot.keyClick(window, Qt.Key_O, Qt.ControlModifier)
+        qtbot.waitUntil(check_dialog)
+    return new_func
+
+
+def create_scene(dataset_ids):
+    class _SceneMock(object):
+        """Fake Satpy Scene object."""
+
+        def __init__(self, *args, **kwargs):
+            """Allow any arguments or kwargs."""
+            pass
+
+        def available_dataset_ids(self):
+            return dataset_ids
+
+    return _SceneMock
+
+
+def _get_group_files_mock(groups):
+    """Create a fake group_files function for testing."""
+    def _group_files_mock(*args, **kwargs):
+        """Fake Satpy group_files function."""
+        return groups
+    return _group_files_mock
+
+
+@need_wizard_test
+def test_cmd_open_export_image_dialog(qtbot, window):
+    """Run our actual in-dialog tests."""
+    wiz = get_wizard_object(window)
+    qtbot.addWidget(wiz)
+    wiz.close()
+
+
+def _create_get_open_file_names_mock(returned_files):
+    def _get_open_file_names(self_, msg, start_dir, filter_str):
+        return [returned_files]
+    return _get_open_file_names
+
+
+def test_wizard_abi_l1b(qtbot, monkeypatch):
+    from satpy import DatasetID
+    files = ['OR_ABI-L1b-RadM1-M3C01_G16_s20182541300210_e20182541300267_c20182541300308.nc']
+    dataset_ids = [
+        # test that floating point resolutions don't crash
+        DatasetID(name='C01', resolution=1000.5, calibration='reflectance'),
+        # radiance calibrations should be ignored by default
+        DatasetID(name='C01', resolution=1000.5, calibration='radiance'),
+    ]
+    # Don't actually talk to Satpy
+    monkeypatch.setattr('uwsift.view.open_file_wizard.Scene', create_scene(dataset_ids))
+    monkeypatch.setattr('uwsift.view.open_file_wizard.group_files',
+                        _get_group_files_mock([{'abi_l1b': files}]))
+    # Add some ABI L1b files to the file list when add button is clicked
+    monkeypatch.setattr('uwsift.view.open_file_wizard.QtWidgets.QFileDialog.getOpenFileNames',
+                        _create_get_open_file_names_mock(
+                            ['OR_ABI-L1b-RadM1-M3C01_G16_s20182541300210_e20182541300267_c20182541300308.nc']))
+
+    # open the dialog and do some things
+    wiz = OpenFileWizard()
+    qtbot.addWidget(wiz)
+    wiz.show()
+
+    ## Page 1
+    # Set reader to ABI L1b
+    wiz.ui.readerComboBox.setCurrentIndex(wiz.ui.readerComboBox.findData('abi_l1b'))
+    # Add a single file (see mock above)
+    qtbot.mouseClick(wiz.ui.addButton, Qt.LeftButton)
+    # Adding this file for the 'abi_l1b' should make this page complete
+    assert wiz.button(wiz.WizardButton.NextButton).isEnabled()
+    # Go to the next page
+    wiz.next()
+
+    ## Page 2
+    # One product should be listed from our mocking above
+    assert wiz.ui.selectIDTable.rowCount() == 1
+    for row_idx in range(wiz.ui.selectIDTable.rowCount()):
+        item = wiz.ui.selectIDTable.item(row_idx, 0)
+        assert item.checkState() == Qt.Checked
+    # A product is selected, that should be to good for the next page
+    assert wiz.button(wiz.WizardButton.FinishButton).isEnabled()
+    # Go to the next page
+    wiz.next()
+
+    # Verify the wizard is left in a usable state for the MainWindow
+    assert len(wiz.scenes) == 1
+    sel_ids = wiz.collect_selected_ids()
+    assert len(sel_ids) == 1
+

--- a/uwsift/tests/view/test_open_file_wizard.py
+++ b/uwsift/tests/view/test_open_file_wizard.py
@@ -96,7 +96,7 @@ def test_wizard_abi_l1b(qtbot, monkeypatch):
         assert item.checkState() == Qt.Checked
     # A product is selected, that should be to good for the next page
     # HACK: Bug in Windows, no enum's by name
-    assert wiz.button(getattr(QWizard.WizardButton, 'FinishButton', 1)).isEnabled()
+    assert wiz.button(getattr(QWizard.WizardButton, 'FinishButton', 3)).isEnabled()
     # Go to the next page
     wiz.next()
 

--- a/uwsift/view/open_file_wizard.py
+++ b/uwsift/view/open_file_wizard.py
@@ -276,9 +276,9 @@ class OpenFileWizard(QtWidgets.QWizard):
             elif key == 'wavelength':
                 pretty_val = "{:0.02f} µm".format(value[1])
             elif key == 'level':
-                pretty_val = "{:d} hPa".format(value)
+                pretty_val = "{:d} hPa".format(int(value))
             elif key == 'resolution':
-                pretty_val = "{:d}m".format(value)
+                pretty_val = "{:d}m".format(int(value))
             else:
                 pretty_val = value
 

--- a/uwsift/workspace/guidebook.py
+++ b/uwsift/workspace/guidebook.py
@@ -18,7 +18,7 @@ __docformat__ = 'reStructuredText'
 
 import logging
 
-from uwsift.common import Info, Kind, Platform, Instrument
+from uwsift.common import Info, Platform, Instrument
 from uwsift.view.colormap import DEFAULT_IR, DEFAULT_VIS, DEFAULT_UNKNOWN
 
 LOG = logging.getLogger(__name__)

--- a/uwsift/workspace/importer.py
+++ b/uwsift/workspace/importer.py
@@ -713,7 +713,7 @@ class GoesRPUGImporter(aSingleFileWithSingleProductImporter):
         is_netcdf = (fn.lower().endswith('.nc') or fn.lower().endswith('.nc4'))
         if not is_netcdf:
             raise ValueError("PUG loader requires files ending in .nc or .nc4: {}".format(repr(source_path)))
-        return PugFile.attach(source_path)
+        return PugFile.attach(source_path)  # noqa
         # if 'L1b' in fn:
         #     LOG.debug('attaching {} as PUG L1b'.format(source_path))
         #     return PugL1bTools(source_path)


### PR DESCRIPTION
Closes #265 

Some how I got lucky and assumed that `resolution` from Satpy was always an integer. This forces resolutions to an integer number to be formatted in the open file wizard dialog.