### PR TITLE
Recognize GEO-KOMPSAT-2A satellite and LI and GLM instruments

### DIFF
--- a/uwsift/common.py
+++ b/uwsift/common.py
@@ -196,6 +196,8 @@ class Instrument(Enum):
     GFS = 'GFS'
     NAM = 'NAM'
     SEVIRI = 'SEVIRI'
+    LI = 'LI'
+    GLM = 'GLM'
 
 
 INSTRUMENT_MAP = {v.value.lower().replace('-', ''): v for v in Instrument}
@@ -213,6 +215,7 @@ class Platform(Enum):
     MSG9 = 'Meteosat-9'
     MSG10 = 'Meteosat-10'
     MSG11 = 'Meteosat-11'
+    GK2A = "GEO-KOMPSAT-2A"
 
 
 PLATFORM_MAP = {v.value.lower().replace('-', ''): v for v in Platform}

--- a/uwsift/model/document.py
+++ b/uwsift/model/document.py
@@ -134,7 +134,7 @@ def _unit_format_func(layer, units):
     else:
         # default formatting string
         def _format_unit(val, numeric=True, include_units=True):
-            return '{:.03f}{units:s}'.format(val, units=units if include_units else "")
+            return '{:.03f} {units:s}'.format(val, units=units if include_units else "")
 
     return _format_unit
 


### PR DESCRIPTION
@ScottLindstrom pointed out that GK2A AMI data shows up as having a `???` platform. This should fix that as well as the same issue that may have come up with LI and GLM instrument data.