### PR TITLE
[WIP] Fix layer selection and layer removal

### DIFF
--- a/uwsift/control/layer_tree.py
+++ b/uwsift/control/layer_tree.py
@@ -354,11 +354,8 @@ class LayerStackTreeViewModel(QAbstractItemModel):
         self.layoutChanged.emit()
 
         # this is an ugly way to make sure the selection stays current
-        try:
-            self.changedSelection(None)
-            self.current_set_listbox.update()
-        except IndexError:
-            pass
+        self.changedSelection(None)
+        self.current_set_listbox.update()
 
     def current_selected_uuids(self, lbox: QTreeView = None):
         lbox = self.current_set_listbox if lbox is None else lbox
@@ -396,8 +393,10 @@ class LayerStackTreeViewModel(QAbstractItemModel):
         :param uuid:
         :return:
         """
+        self.layoutAboutToBeChanged.emit()
+        self.removeRows(row, count)
+        self.layoutChanged.emit()
         self.refresh()
-        # self.removeRows(row, count)
 
     def update_equalizer(self, doc_values):
         """


### PR DESCRIPTION
Closes #276 

I think a lot of the issues about this are caused by things in PyQt4 that we were working around and have now been fixed in PyQt5. The problem is, we are doing so many things that are hacky that it is hard to tell what is supposed to be there and what isn't.