### PR TITLE
Fix incorrectly grouping layers from the same scene

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 env:
   global:
   - PYTHON_VERSION=$TRAVIS_PYTHON_VERSION
-  - NUMPY_VERSION=stable
+  - NUMPY_VERSION=1.17
   - MAIN_CMD='python setup.py'
   - CONDA_DEPENDENCIES='hdf5 rasterio matplotlib numba pyproj coveralls pytest pytest-mock
     pytest-cov pytest-qt vispy netcdf4 h5py imageio imageio-ffmpeg ffmpeg

--- a/uwsift/workspace/importer.py
+++ b/uwsift/workspace/importer.py
@@ -1094,7 +1094,15 @@ class SatpyImporter(aImporter):
                 model_time = ds.attrs['model_time'].isoformat()
             else:
                 model_time = None
-            ds.attrs[Info.SCENE] = ds.attrs.get('scene_id') or hash(ds.attrs['area'])
+            ds.attrs[Info.SCENE] = ds.attrs.get('scene_id')
+            if ds.attrs[Info.SCENE] is None:
+                # compute a "good enough" hash for this Scene
+                area = ds.attrs['area']
+                extents = area.area_extent
+                # round extents to nearest 100 meters
+                extents = tuple(int(np.round(x / 100.0) * 100.0) for x in extents)
+                proj_str = area.proj4_string
+                ds.attrs[Info.SCENE] = "{}-{}".format(str(extents), proj_str)
             if ds.attrs.get(Info.CENTRAL_WAVELENGTH) is None:
                 cw = ""
             else:


### PR DESCRIPTION
Closes #278 

As a last resort, which turned out to be most cases, I had the Satpy importer do a `hash(area_def)` of the AreaDefinition object to determine the "SCENE" of a layer. In the past for ABI we've had this hardcoded as CONUS or FLDK or similar based on available metadata. At least at the time of this writing this information is not standard in Satpy, hence the fallback of `hash`. However, this was foolish as the AreaDefinition is going to be different for every resolution. This means bands at 1km are considered a different "SCENE" from the 0.5km and 2km bands.

This PR fixes that by rounding the are extents to the nearest 100m boundaries and using that and the PROJ definition as a "unique identifier" for the Scene when we don't have a human readable name available to us from Satpy.