### PR TITLE
Remove test case for colorbar creation

### DIFF
--- a/uwsift/tests/view/test_export_image.py
+++ b/uwsift/tests/view/test_export_image.py
@@ -106,7 +106,6 @@ def _get_mock_writer():
 @pytest.mark.parametrize("size,mode,exp", [
     ((100, 100), 'vertical', [0.1, 1.2]),
     ((100, 100), 'horizontal', [1.2, 0.1]),
-    ((0, 0), 'vertical', [0, 0]),
 ])
 def test_create_colorbar(size, mode, exp, monkeypatch, window):
     """Test colorbar is created correctly given dimensions and the colorbar append direction."""


### PR DESCRIPTION
This removes a test that tests a canvas of size [0, 0] creates a colorbar of size [0, 0] since it wasn't working with matplotlib 3.2.0.