### PR TITLE
[WIP] First steps in fixing SIFT to auto-flip SEVIRI data

### DIFF
--- a/uwsift/workspace/importer.py
+++ b/uwsift/workspace/importer.py
@@ -1127,14 +1127,16 @@ class SatpyImporter(aImporter):
             raise NotImplementedError("Only AreaDefinition datasets can "
                                       "be loaded at this time.")
 
-        half_pixel_x = abs(area.pixel_size_x) / 2.
-        half_pixel_y = abs(area.pixel_size_y) / 2.
+        half_pixel_x = area.pixel_size_x / 2.
+        half_pixel_y = area.pixel_size_y / 2.
+        print(half_pixel_x, half_pixel_y)
+        print(area.area_extent)
 
         return {
             Info.PROJ: area.proj4_string,
             Info.ORIGIN_X: area.area_extent[0] + half_pixel_x,
             Info.ORIGIN_Y: area.area_extent[3] - half_pixel_y,
-            Info.CELL_HEIGHT: -abs(area.pixel_size_y),
+            Info.CELL_HEIGHT: -area.pixel_size_y,
             Info.CELL_WIDTH: area.pixel_size_x,
         }
 


### PR DESCRIPTION
This is mainly here so I don't lose this and when someone brings it up and I say "I'm pretty sure I already tried to make this work" I can easily find the code.

This PR attempts to change the handling of geolocation information to allow data that is flipped along one or more axes. This is the case for SEVIRI data in most formats (x and y dimensions are flipped) and FCI (y dimension is flipped). However, this currently doesn't work perfectly. I originally thought this wasn't going to be that hard to I gave it a shot, but ran in to a lot of complications when it came to figuring out where an image's tiles are (ex. where is tile (0, 0)). A lot of the changes were pretty straight forward; stop doing absolute value of the pixel resolution everywhere and change all `-` in the `y` dimension to `+` to match what is being done for the `x` dimension. This mostly worked, but the navigation is still off when displayed on the map:

![Screenshot_20200508_163459](https://user-images.githubusercontent.com/1828519/82493746-14130800-9aae-11ea-910b-5c38b743d345.png)
