### PR TITLE
Limit vispy to less than 0.7 to future proof against the next release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ env:
   - NUMPY_VERSION=stable
   - MAIN_CMD='python setup.py'
   - CONDA_DEPENDENCIES='hdf5 rasterio matplotlib numba pyproj coveralls pytest pytest-mock
-    pytest-cov coverage pytest-qt vispy netcdf4 h5py imageio imageio-ffmpeg ffmpeg
+    pytest-cov coverage pytest-qt vispy<0.7 netcdf4 h5py imageio imageio-ffmpeg ffmpeg
     pillow pyshp pyqtgraph shapely sqlalchemy pyqt appdirs pyyaml satpy eccodes scikit-image
     donfig conda-pack'
   - PIP_DEPENDENCIES='pytest-xvfb'

--- a/setup.py
+++ b/setup.py
@@ -190,7 +190,7 @@ setup(
                  "Topic :: Scientific/Engineering"],
     zip_safe=False,
     include_package_data=True,
-    install_requires=['numpy', 'pillow', 'numba', 'vispy>=0.6.0',
+    install_requires=['numpy', 'pillow', 'numba', 'vispy>=0.6.0,<0.7.0',
                       'netCDF4', 'h5py', 'pyproj',
                       'pyshp', 'shapely', 'rasterio', 'sqlalchemy',
                       'appdirs', 'pyyaml', 'pyqtgraph', 'satpy', 'matplotlib',

--- a/uwsift/tests/view/test_export_image.py
+++ b/uwsift/tests/view/test_export_image.py
@@ -121,7 +121,7 @@ def test_create_colorbar(size, mode, exp, monkeypatch, window):
 @pytest.mark.parametrize("mode,cbar_size,exp", [
     (None, (0, 0), (100, 100)),
     ('vertical', (10, 120), (108, 100)),
-    ('horizontal', (120, 10), (100, 109)),
+    ('horizontal', (110, 10), (100, 109)),
 ])
 def test_append_colorbar(mode, cbar_size, exp, monkeypatch, window):
     """Test colorbar is appended to the appropriate location given the colorbar append direction."""


### PR DESCRIPTION
The next version of vispy (currently unreleased) makes some major changes to the ImageVisual. Normally this wouldn't be a problem for users, but we are hacking into the ImageVisual pretty heavily.

This also makes the colorbar tests a little more consistent between versions of PIL so they can pass on more systems. See https://pillow.readthedocs.io/en/stable/releasenotes/7.0.0.html#better-thumbnail-geometry

That means this closes #286 