### PR TITLE
Fix bundle script having wrong permissions and activation path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,9 @@ matrix:
     env: PYTHON_VERSION=3.7
     language: c
 before_install:
-  - openssl aes-256-cbc -K $encrypted_f8c2318670e7_key -iv $encrypted_f8c2318670e7_iv
-    -in id_rsa_sift_sftp.enc -out /tmp/sftp_rsa -d
+  - if [ ! -z $encrypted_f8c2318670e7_iv ]; then
+        openssl aes-256-cbc -K $encrypted_f8c2318670e7_key -iv $encrypted_f8c2318670e7_iv -in id_rsa_sift_sftp.enc -out /tmp/sftp_rsa -d;
+    fi
 install:
 - git clone --depth 1 git://github.com/astropy/ci-helpers.git
 - source ci-helpers/travis/setup_conda.sh

--- a/build_conda_pack.py
+++ b/build_conda_pack.py
@@ -55,13 +55,13 @@ def main():
     script_dir = os.path.realpath(os.path.dirname(__file__))
     if 'nux' in sys.platform:
         script = os.path.join(script_dir, 'bundle_scripts', 'SIFT.sh')
-        shutil.copyfile(script, os.path.join(dst, 'SIFT.sh'))
+        shutil.copy(script, os.path.join(dst, 'SIFT.sh'))
     elif 'darwin' in sys.platform:
         script = os.path.join(script_dir, 'bundle_scripts', 'SIFT.sh')
-        shutil.copyfile(script, os.path.join(dst, 'SIFT.command'))
+        shutil.copy(script, os.path.join(dst, 'SIFT.command'))
     elif 'win' in sys.platform:
         script = os.path.join(script_dir, 'bundle_scripts', 'SIFT.bat')
-        shutil.copyfile(script, os.path.join(dst, 'SIFT.bat'))
+        shutil.copy(script, os.path.join(dst, 'SIFT.bat'))
     else:
         raise RuntimeError(f"Unknown platform: {sys.platform}")
 

--- a/bundle_scripts/SIFT.sh
+++ b/bundle_scripts/SIFT.sh
@@ -16,7 +16,7 @@ unset PYTHONPATH
 export PYTHONNOUSERSITE=1
 
 # Activate the conda-pack'd environment
-source $BASE/activate
+source $BASE/bin/activate
 
 # Check if we already ran conda-unpack
 install_signal="${BASE}/.installed"


### PR DESCRIPTION
After some testing by @rayg-ssec, we found out that the activation script path in the linux/osx scripts is wrong. Also the executable permissions were removed. This PR should fix both.