### PR TITLE
Fix HiDPI setting being set too late

### DIFF
--- a/uwsift/__main__.py
+++ b/uwsift/__main__.py
@@ -55,11 +55,6 @@ from uwsift.view.scene_graph import SceneGraphManager
 from uwsift.workspace import Workspace
 from uwsift.workspace.collector import ResourceSearchPathCollector
 
-app_object = app.use_app('pyqt5')
-APP: QtGui.QApplication = app_object.native
-# LOOP = QEventLoop(APP)
-# asyncio.set_event_loop(LOOP)  # NEW must set the event loop
-
 LOG = logging.getLogger(__name__)
 PROGRESS_BAR_MAX = 1000
 STATUS_BAR_DURATION = 2000  # ms
@@ -654,7 +649,7 @@ class Main(QtGui.QMainWindow):
         LOG.debug("Potential tracks: {}".format(repr(doc.track_order)))
         self._timeline_scene = SiftDocumentAsFramesInTracks(doc, self.workspace)
         gv.setScene(self._timeline_scene)
-        APP.aboutToQuit.connect(self._timeline_scene.clear)
+        QtWidgets.QApplication.instance().aboutToQuit.connect(self._timeline_scene.clear)
 
         self._timeline_scene.sync_items()
 
@@ -1176,10 +1171,11 @@ def main():
 
     LOG.info("Using configuration directory: %s", args.config_dir)
     LOG.info("Using cache directory: %s", args.cache_dir)
-    app.create()
-    APP.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
+    QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
+    vispy_app = app.use_app('pyqt5')
+    qt_app = vispy_app.create()
     if hasattr(QtWidgets.QStyleFactory, 'AA_UseHighDpiPixmaps'):
-        APP.setAttribute(QtCore.Qt.AA_UseHighDpiPixmaps)
+        qt_app.setAttribute(QtCore.Qt.AA_UseHighDpiPixmaps)
 
     # Add our own fonts to Qt windowing system
     font_pattern = os.path.join(get_package_data_dir(), 'fonts', '*')
@@ -1204,8 +1200,7 @@ def main():
     window.show()
     # bring window to front
     window.raise_()
-    # LOOP.run_forever()
-    app.run()
+    vispy_app.run()
 
 
 if __name__ == '__main__':

--- a/uwsift/__main__.py
+++ b/uwsift/__main__.py
@@ -1128,6 +1128,15 @@ def _search_paths(arglist):
             yield subpath
 
 
+def create_app() -> (app.Application, QtWidgets.QApplication):
+    QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
+    vispy_app = app.use_app('pyqt5')
+    qt_app = vispy_app.create()
+    if hasattr(QtWidgets.QStyleFactory, 'AA_UseHighDpiPixmaps'):
+        qt_app.setAttribute(QtCore.Qt.AA_UseHighDpiPixmaps)
+    return vispy_app, qt_app
+
+
 def main():
     import argparse
     parser = argparse.ArgumentParser(description="Run SIFT")
@@ -1171,11 +1180,7 @@ def main():
 
     LOG.info("Using configuration directory: %s", args.config_dir)
     LOG.info("Using cache directory: %s", args.cache_dir)
-    QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
-    vispy_app = app.use_app('pyqt5')
-    qt_app = vispy_app.create()
-    if hasattr(QtWidgets.QStyleFactory, 'AA_UseHighDpiPixmaps'):
-        qt_app.setAttribute(QtCore.Qt.AA_UseHighDpiPixmaps)
+    vispy_app, qt_app = create_app()
 
     # Add our own fonts to Qt windowing system
     font_pattern = os.path.join(get_package_data_dir(), 'fonts', '*')

--- a/uwsift/tests/conftest.py
+++ b/uwsift/tests/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-from uwsift.__main__ import Main
+from uwsift.__main__ import Main, create_app
 from uwsift.util.default_paths import USER_CONFIG_DIR
 from PyQt5.QtTest import QTest
 
@@ -7,6 +7,7 @@ from PyQt5.QtTest import QTest
 @pytest.fixture(scope="session")
 def window(tmp_path_factory):
     """Provides the SIFT GUI to tests."""
+    vispy_app, qt_app = create_app()  # noqa
     d = tmp_path_factory.mktemp("tmp")
     window = Main(config_dir=USER_CONFIG_DIR, workspace_dir=str(d))
     window.show()


### PR DESCRIPTION
The HiDPI setting for Qt5 needs to be set before the QApplication is created. This PR does that along while also rearranging when the app is created.