### PR TITLE
Update bundle scripts to handle installation directory being moved

### DIFF
--- a/bundle_scripts/SIFT.bat
+++ b/bundle_scripts/SIFT.bat
@@ -8,11 +8,19 @@ call %base_dir%Scripts\activate
 
 REM Create a signal file that we have run conda-unpack
 set installed=%base_dir%.installed
-if not exist "%installed%" (
+if not exist "%installed%" goto install
+
+set /p install_dir=< %installed%
+if not %base_dir% == %install_dir:~0,-1% goto install
+
+goto run_sift
+
+:install 
   echo Running one-time initialization of SIFT installation...
   conda-unpack
   echo %base_dir% > %installed%
-)
+
+:run_sift
 
 echo Running SIFT...
 

--- a/bundle_scripts/SIFT.sh
+++ b/bundle_scripts/SIFT.sh
@@ -20,7 +20,7 @@ source $BASE/bin/activate
 
 # Check if we already ran conda-unpack
 install_signal="${BASE}/.installed"
-if [[ ! -f "${install_signal}" ]]; then
+if [[ "$(head -n 1 ${install_signal} 2>/dev/null)" != "${BASE}" ]]; then
     echo "Running one-time initialization of SIFT installation..."
     conda-unpack
     echo "${BASE}" > "${install_signal}"


### PR DESCRIPTION
Attempt at fixing #295. At the time of writing this is just the `.sh` script, but should work.

I started researching `.bat` file solutions and came across this: https://stackoverflow.com/questions/130116/windows-batch-commands-to-read-first-line-from-text-file. I'm not sure how Windows handles newlines and carriage returns the way @katherinekolman has it writing to the file. Kat do you think you could look in to this and test it on Windows? The idea is that if you run SIFT once, then move the directory to a new directory and run it again, conda-unpack should run and data should load fine.