### PR TITLE
297 Relocate qt.conf after conda-unpack for Windows

### DIFF
--- a/bundle_scripts/SIFT.bat
+++ b/bundle_scripts/SIFT.bat
@@ -1,7 +1,7 @@
 @echo off
 REM Initialize SIFT installation if necessary and run SIFT
 
-set base_dir=%~p0
+set base_dir=%~dp0
 
 REM Activate the conda environment
 call %base_dir%Scripts\activate

--- a/bundle_scripts/SIFT.bat
+++ b/bundle_scripts/SIFT.bat
@@ -11,6 +11,7 @@ set installed=%base_dir%.installed
 if not exist "%installed%" (
   echo Running one-time initialization of SIFT installation...
   conda-unpack
+  python %base_dir%\qt_conf_fix.py %base_dir%
   echo %base_dir% > %installed%
 )
 

--- a/bundle_scripts/qt_conf_fix.py
+++ b/bundle_scripts/qt_conf_fix.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# Relocate qt.conf after conda-unpack for Windows (see SIFT.bat)
+# example qt.conf file before relocation:
+#
+# [Paths]
+# Prefix = C:/tools/miniconda3/envs/test/Library
+# Binaries = C:/tools/miniconda3/envs/test/Library/bin
+# Libraries = C:/tools/miniconda3/envs/test/Library/lib
+# Headers = C:/tools/miniconda3/envs/test/Library/include/qt
+# TargetSpec = win32-msvc
+# HostSpec = win32-msvc
+
+import sys
+import os
+import re
+
+
+def main(base):
+    fn_qt_conf = os.path.join(base, 'qt.conf')
+    with open(fn_qt_conf, 'rt') as fob:
+        txt = fob.read()
+        fob.close()
+    src, = re.findall(r'Prefix\s*=\s*(.*?)Library', txt, re.MULTILINE)
+    dst = base.replace('\\', '/')
+    if not dst.endswith('/'):
+        dst += '/'
+    print(f"Relocating qt.conf from {src} to {dst}")
+    new_txt = txt.replace(src, dst)
+    with open(fn_qt_conf, 'wt') as fob:
+        fob.write(new_txt)
+        fob.close()
+
+
+if __name__ == '__main__':
+    main(*sys.argv[1:])
+

--- a/bundle_scripts/qt_conf_fix.py
+++ b/bundle_scripts/qt_conf_fix.py
@@ -33,4 +33,3 @@ def main(base):
 
 if __name__ == '__main__':
     main(*sys.argv[1:])
-


### PR DESCRIPTION
This fixes inability to start the bundled form of SIFT on Windows. Tested in a VM by manually adding to SIFT 1.1.3 test bundle, so it may yet need addition to any manifest for the bundle build (have not found one so far).
- SIFT.bat now uses %~dp0 to include drive letter of the install location.
- qt_conf_fix.py is run by SIFT.bat at the time that conda-unpack is completed (first run).
- qt_conf_fix.py replaces Qt Library locations in qt.conf, required in order to start up.
- qt_conf_fix.py could be used by Unix OSes if also needed there, it takes the install directory base as its singular argument.

