### PR TITLE
Update backend_qt4agg import to backend_qt5agg

### DIFF
--- a/build_conda_pack.py
+++ b/build_conda_pack.py
@@ -67,10 +67,8 @@ def main():
 
     # HACK: https://github.com/conda/conda-pack/issues/141
     if sys.platform.startswith('win'):
-        desired_prefix = sys.prefix  # escaped backslashes (\\)
-        in_file_prefix = sys.prefix.replace('\\', '/')
         with open(os.path.join(sys.prefix, 'qt.conf')) as qtconf:
-            new_text = qtconf.read().replace(in_file_prefix, desired_prefix)
+            new_text = qtconf.read().replace('/', r'\\')
         with open(os.path.join(sys.prefix, 'qt.conf'), 'w') as qtconf:
             qtconf.write(new_text)
         with open(os.path.join(sys.prefix, 'Library', 'bin', 'qt.conf'), 'w') as qtconf:

--- a/uwsift/view/probes.py
+++ b/uwsift/view/probes.py
@@ -19,8 +19,8 @@ import numpy as np
 from PyQt5.QtCore import QObject, pyqtSignal
 # http://stackoverflow.com/questions/12459811/how-to-embed-matplotib-in-pyqt-for-dummies
 # see also: http://matplotlib.org/users/navigation_toolbar.html
-from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas
-from matplotlib.backends.backend_qt4agg import NavigationToolbar2QT as NavigationToolbar
+from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
+from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT as NavigationToolbar
 from matplotlib.colors import LogNorm
 from matplotlib.figure import Figure
 


### PR DESCRIPTION
backend_qt4agg is deprecated and we aren't using qt4 anymore. Not sure how this slipped through the cracks.

This PR also includes a simplification to the qt.conf hack of #300 