### PR TITLE
Fix issues related with newer versions of Satpy and Pyyaml

### DIFF
--- a/uwsift/tests/view/test_open_file_wizard.py
+++ b/uwsift/tests/view/test_open_file_wizard.py
@@ -55,13 +55,13 @@ def _create_get_open_file_names_mock(returned_files):
 
 def test_wizard_abi_l1b(qtbot, monkeypatch):
     """Test that the open file wizard works all the way through."""
-    from satpy import DatasetID
+    from satpy.tests.utils import make_dataid
     files = ['OR_ABI-L1b-RadM1-M3C01_G16_s20182541300210_e20182541300267_c20182541300308.nc']
     dataset_ids = [
         # test that floating point resolutions don't crash
-        DatasetID(name='C01', resolution=1000.5, calibration='reflectance'),
+        make_dataid(name='C01', resolution=1000.5, calibration='reflectance'),
         # radiance calibrations should be ignored by default
-        DatasetID(name='C01', resolution=1000.5, calibration='radiance'),
+        make_dataid(name='C01', resolution=1000.5, calibration='radiance'),
     ]
     # Don't actually talk to Satpy
     monkeypatch.setattr('uwsift.view.open_file_wizard.Scene', create_scene(dataset_ids))

--- a/uwsift/tests/workspace/test_importer.py
+++ b/uwsift/tests/workspace/test_importer.py
@@ -8,7 +8,8 @@ import xarray as xr
 import numpy as np
 import dask.array as da
 from datetime import datetime
-from satpy import DatasetID, Scene
+from satpy import Scene
+from satpy.tests.utils import make_dataid
 from pyresample.geometry import AreaDefinition
 from uwsift.workspace.importer import available_satpy_readers, SatpyImporter
 from uwsift.common import Info, Kind
@@ -114,7 +115,7 @@ def test_satpy_importer_basic(tmpdir, monkeypatch, mocker):
     imp = SatpyImporter(['/test/file.nc'], tmpdir, db_sess,
                         scene=scn,
                         reader='abi_l1b',
-                        dataset_ids=[DatasetID(name='C01')])
+                        dataset_ids=[make_dataid(name='C01')])
     imp.merge_resources()
     assert imp.num_products == 1
     products = list(imp.merge_products())
@@ -153,7 +154,7 @@ def test_satpy_importer_contour_0_360(tmpdir, monkeypatch, mocker):
     imp = SatpyImporter(['/test/file.nc'], tmpdir, db_sess,
                         scene=scn,
                         reader='grib',
-                        dataset_ids=[DatasetID(name='gh', level=125)])
+                        dataset_ids=[make_dataid(name='gh', level=125)])
     imp.merge_resources()
     assert imp.num_products == 1
     products = list(imp.merge_products())


### PR DESCRIPTION
Missed a few tests that needed updating from #301 and found new bugs related to pyyaml saving python tuples as python/tuple objects instead of lists like it used to. This should all be fixed now.