### PR TITLE
Fix importing data with newer versions of Satpy

### DIFF
--- a/uwsift/__main__.py
+++ b/uwsift/__main__.py
@@ -922,7 +922,7 @@ class Main(QtGui.QMainWindow):
         if wizard_dialog.exec_():
             LOG.info("Loading products from open wizard...")
             scenes = wizard_dialog.scenes
-            reader = list(list(scenes.values())[0].readers.keys())[0]
+            reader = wizard_dialog.previous_reader
             importer_kwargs = {
                 'reader': reader,
                 'scenes': scenes,

--- a/uwsift/tests/view/test_open_file_wizard.py
+++ b/uwsift/tests/view/test_open_file_wizard.py
@@ -102,5 +102,6 @@ def test_wizard_abi_l1b(qtbot, monkeypatch):
 
     # Verify the wizard is left in a usable state for the MainWindow
     assert len(wiz.scenes) == 1
+    assert wiz.previous_reader == 'abi_l1b'
     sel_ids = wiz.collect_selected_ids()
     assert len(sel_ids) == 1

--- a/uwsift/view/open_file_wizard.py
+++ b/uwsift/view/open_file_wizard.py
@@ -54,7 +54,7 @@ class OpenFileWizard(QtWidgets.QWizard):
         # tuple(filenames) -> scene object
         self.scenes = {}
         self.all_available_products = None
-        self._previous_reader = None
+        self.previous_reader = None
         self.file_groups = {}
         self.unknown_files = set()
         app = QtWidgets.QApplication.instance()
@@ -200,13 +200,13 @@ class OpenFileWizard(QtWidgets.QWizard):
     def _group_files(self, reader) -> bool:
         """Group provided files by time step."""
         # the files haven't changed since we were last run
-        if not self._filelist_changed and self._previous_reader == reader:
+        if not self._filelist_changed and self.previous_reader == reader:
             return False
 
         self._filelist_changed = False
         self.file_groups = {}  # reset the list, just in case
         selected_files = self._all_filenames.copy()
-        self._previous_reader = reader
+        self.previous_reader = reader
         file_groups = group_files(selected_files, reader=reader)
         if not file_groups:
             self.unknown_files = selected_files


### PR DESCRIPTION
Satpy 0.25.0 made the Scene `.readers` attribute private (`._readers`). This fixes the use of that change which was unnecessary in the first place.