### PR TITLE
Replace / with \\ throughout Prefix where present in qt.conf, to fix …

### DIFF
--- a/build_conda_pack.py
+++ b/build_conda_pack.py
@@ -19,6 +19,7 @@ import os
 import sys
 import shutil
 import subprocess
+import re
 
 
 def get_version():
@@ -67,11 +68,14 @@ def main():
 
     # HACK: https://github.com/conda/conda-pack/issues/141
     if sys.platform.startswith('win'):
-        with open(os.path.join(sys.prefix, 'qt.conf')) as qtconf:
-            new_text = qtconf.read().replace('/', r'\\')
-        with open(os.path.join(sys.prefix, 'qt.conf'), 'w') as qtconf:
+        with open(os.path.join(sys.prefix, 'qt.conf'), 'rt') as qtconf:
+            old_text = qtconf.read()
+        old_prefix, = tuple(re.findall(r'^Prefix\s*=\s*(.*?)\s*$', old_text, re.MULTILINE))
+        new_prefix = old_prefix.replace('/', '\\')
+        new_text = old_text.replace(old_prefix, new_prefix)
+        with open(os.path.join(sys.prefix, 'qt.conf'), 'wt') as qtconf:
             qtconf.write(new_text)
-        with open(os.path.join(sys.prefix, 'Library', 'bin', 'qt.conf'), 'w') as qtconf:
+        with open(os.path.join(sys.prefix, 'Library', 'bin', 'qt.conf'), 'wt') as qtconf:
             qtconf.write(new_text)
 
     subprocess.check_call(['conda-pack', '--arcroot', args.arcroot,


### PR DESCRIPTION
Partially tested qt.conf update during packaging to address #308 
- Extract Prefix string
- replace / with \\ in Prefix
- replace prefix string with new version throughout qt.conf configuration file

Also now uses text-mode open() when reading and writing qt.conf.

This is intended to allow conda-unpack to properly detect and amend Prefix on Windows.