### PR TITLE
Retain forward slash before Libary in prefix

### DIFF
--- a/build_conda_pack.py
+++ b/build_conda_pack.py
@@ -70,7 +70,7 @@ def main():
     if sys.platform.startswith('win'):
         with open(os.path.join(sys.prefix, 'qt.conf'), 'rt') as qtconf:
             old_text = qtconf.read()
-        old_prefix, = tuple(re.findall(r'^Prefix\s*=\s*(.*?)\s*$', old_text, re.MULTILINE))
+        old_prefix, = tuple(re.findall(r'^Prefix\s*=\s*(.*?).Library\s*$', old_text, re.MULTILINE))
         new_prefix = old_prefix.replace('/', '\\')
         new_text = old_text.replace(old_prefix, new_prefix)
         with open(os.path.join(sys.prefix, 'qt.conf'), 'wt') as qtconf:


### PR DESCRIPTION
Revised for #308 after 1.1.5 found unviable for win32