### PR TITLE
Fix CI using old version of vispy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ env:
   - NUMPY_VERSION=stable
   - MAIN_CMD='python setup.py'
   - CONDA_DEPENDENCIES='hdf5 rasterio matplotlib numba pyproj coveralls pytest pytest-mock
-    pytest-cov coverage pytest-qt vispy<0.7 netcdf4 h5py imageio imageio-ffmpeg ffmpeg
+    pytest-cov coverage pytest-qt vispy netcdf4 h5py imageio imageio-ffmpeg ffmpeg
     pillow pyshp pyqtgraph shapely sqlalchemy pyqt appdirs pyyaml satpy eccodes scikit-image
     donfig conda-pack'
   - PIP_DEPENDENCIES='pytest-xvfb'


### PR DESCRIPTION
We used to depend on vispy<0.7, but now we don't. The old version was causing travis CI tests to fail.