### PR TITLE
Improve log message when tiled image isn't displayed

### DIFF
--- a/uwsift/view/tile_calculator.py
+++ b/uwsift/view/tile_calculator.py
@@ -170,8 +170,7 @@ def calc_view_extents(image_extents_box: Box, canvas_point, image_point, canvas_
     top = clip(top, image_extents_box.bottom, image_extents_box.top)
 
     if (right - left) < CANVAS_EXTENTS_EPSILON or (top - bot) < CANVAS_EXTENTS_EPSILON:
-        # they are viewing essentially nothing or the image isn't in view
-        raise ValueError("Image can't be currently viewed")
+        raise ValueError("Image is outside of canvas or empty")
 
     return Box(left=left, right=right, bottom=bot, top=top)
 

--- a/uwsift/view/visuals.py
+++ b/uwsift/view/visuals.py
@@ -446,8 +446,9 @@ class SIFTTiledGeolocatedMixin:
             view_box = self.get_view_box()
             preferred_stride = self._get_stride(view_box)
             tile_box = self.calc.visible_tiles(view_box, stride=preferred_stride, extra_tiles_box=Box(1, 1, 1, 1))
-        except ValueError:
-            LOG.error("Could not determine viewable image area for '{}'".format(self.name))
+        except ValueError as e:
+            # If image is outside of canvas, then an exception will be raised
+            LOG.warning("Could not determine viewable image area for '{}': {}".format(self.name, e))
             return False, self._stride, self._latest_tile_box
 
         num_tiles = (tile_box.bottom - tile_box.top) * (tile_box.right - tile_box.left)


### PR DESCRIPTION
Original commit message:

```
When the TiledGeolocatedImage is panned to leave the canvas completely a
ValueError exception is raised to notify about this and also a WARNING log
message is generated (it can be discussed, whether this case is worth a
warning, but...). This commit enhances the wording and adds the
ValueError exception message to the log message in the hope to reduce
confusion about its meaning.
```

This is the first commit taken directly from the EUMETSAT gitlab that was contributed by their contractors. It makes sense and is a simple fix. This is a cherry-pick so it completely breaks commit history with their version, but that's going to have to happen if we only merge specific pieces (I'd like to merge all of it).