### PR TITLE
Fix validity check of reprojected mesh in TiledGelocatedImageVisual

### DIFF
--- a/uwsift/view/visuals.py
+++ b/uwsift/view/visuals.py
@@ -390,7 +390,7 @@ class SIFTTiledGeolocatedMixin:
         # The image mesh of only valid "viewable" projected coordinates
         img_vbox = self.calc.image_mesh[valid_mask]
 
-        if not img_cmesh[:, 0].size or not img_cmesh[:, 0].size:
+        if not img_cmesh[:, 0].size or not img_cmesh[:, 1].size:
             self._viewable_mesh_mask = None
             self._ref1, self._ref2 = None, None
             return


### PR DESCRIPTION
Due to a copy/paste bug the x-axis was checked twice whereas the y-axis
was ignored.

Cherry picked from https://gitlab.eumetsat.int/webservices/mtg-sift/-/commit/e07d67893dbf628df7def3b59e7dcd96d69ac105