### PR TITLE
Remove background/overview image tile

### DIFF
--- a/uwsift/view/scene_graph.py
+++ b/uwsift/view/scene_graph.py
@@ -962,12 +962,12 @@ class SceneGraphManager(QObject):
             image.parent = None
             del self.image_elements[layer[Info.UUID]]
 
-        overview_content = self.workspace.get_content(layer.uuid, kind=p.kind)
+        image_data = self.workspace.get_content(layer.uuid, kind=p.kind)
         if p.kind == Kind.CONTOUR:
-            return self.add_contour_layer(layer, p, overview_content)
+            return self.add_contour_layer(layer, p, image_data)
 
         image = TiledGeolocatedImage(
-            overview_content,
+            image_data,
             layer[Info.ORIGIN_X],
             layer[Info.ORIGIN_Y],
             layer[Info.CELL_WIDTH],
@@ -999,11 +999,11 @@ class SceneGraphManager(QObject):
             return
         if p.kind == Kind.RGB:
             dep_uuids = r, g, b = [c.uuid if c is not None else None for c in [layer.r, layer.g, layer.b]]
-            overview_content = list(self.workspace.get_content(cuuid, kind=Kind.IMAGE) for cuuid in dep_uuids)
+            image_data = list(self.workspace.get_content(cuuid, kind=Kind.IMAGE) for cuuid in dep_uuids)
             uuid = layer.uuid
             LOG.debug("Adding composite layer to Scene Graph Manager with UUID: %s", uuid)
             self.image_elements[uuid] = element = RGBCompositeLayer(
-                overview_content,
+                image_data,
                 layer[Info.ORIGIN_X],
                 layer[Info.ORIGIN_Y],
                 layer[Info.CELL_WIDTH],
@@ -1049,15 +1049,14 @@ class SceneGraphManager(QObject):
                     # RGB selection has changed, rebuild the layer
                     LOG.debug("Changing existing composite layer to Scene Graph Manager with UUID: %s", layer.uuid)
                     dep_uuids = r, g, b = [c.uuid if c is not None else None for c in [layer.r, layer.g, layer.b]]
-                    overview_content = list(self.workspace.get_content(cuuid) for cuuid in dep_uuids)
+                    image_arrays = list(self.workspace.get_content(cuuid) for cuuid in dep_uuids)
                     self.composite_element_dependencies[layer.uuid] = dep_uuids
                     elem = self.image_elements[layer.uuid]
-                    elem.set_channels(overview_content,
+                    elem.set_channels(image_arrays,
                                       cell_width=layer[Info.CELL_WIDTH],
                                       cell_height=layer[Info.CELL_HEIGHT],
                                       origin_x=layer[Info.ORIGIN_X],
                                       origin_y=layer[Info.ORIGIN_Y])
-                    elem.init_overview(overview_content)
                     elem.clim = presentation.climits
                     elem.gamma = presentation.gamma
                     self.on_view_change(None)

--- a/uwsift/view/tile_calculator.py
+++ b/uwsift/view/tile_calculator.py
@@ -384,7 +384,6 @@ def calc_stride(v_dx, v_dy, t_dx, t_dy, overview_stride_y, overview_stride_x):
     nb_types.NamedUniTuple(int64, 2, Point)
 ), nopython=True, cache=True, nogil=True)
 def calc_overview_stride(image_shape_y, image_shape_x, tile_shape):
-    # FUTURE: Come up with a fancier way of doing overviews like averaging each strided section, if needed
     tsy = max(1, int(np.floor(image_shape_y / tile_shape[0])))
     tsx = max(1, int(np.floor(image_shape_x / tile_shape[1])))
     return tsy, tsx
@@ -538,6 +537,7 @@ class TileCalculator(object):
                                   self.ul_origin.x + self.image_shape[1] / 2. * self.pixel_rez.dx)
         # size of tile in image projection
         self.tile_size = Resolution(self.pixel_rez.dy * self.tile_shape[0], self.pixel_rez.dx * self.tile_shape[1])
+        # maximum stride that we shouldn't lower resolution beyond
         self.overview_stride = self.calc_overview_stride()
 
     def visible_tiles(self, visible_geom, stride=Point(1, 1), extra_tiles_box=Box(0, 0, 0, 0)) -> Box:


### PR DESCRIPTION
This PR completely removes the "overview" image/tile that always appears under the current image tiles. This has been shown to cause more issues than any benefits it may provide. The main one is that for partial transparent images you can see the overview tile data showing under neath. From basic tests on my part and a lot of testing on EUMETSAT's part, the overview image doesn't seem to be needed and SIFT still provides a quick visualization.