### PR TITLE
Fix half pixel offset for point probing

### DIFF
--- a/uwsift/workspace/workspace.py
+++ b/uwsift/workspace/workspace.py
@@ -1260,7 +1260,8 @@ class Workspace(QObject):
             x, y = Proj(info[Info.PROJ])(*xy_pos)
         col = (x - info[Info.ORIGIN_X]) / info[Info.CELL_WIDTH]
         row = (y - info[Info.ORIGIN_Y]) / info[Info.CELL_HEIGHT]
-        return np.int64(np.round(row)), np.int64(np.round(col))
+
+        return np.int64(np.floor(row)), np.int64(np.floor(col))
 
     def layer_proj(self, dsi_or_uuid):
         """Project lon/lat probe points to image X/Y"""


### PR DESCRIPTION
Cherry-pick'd from EUMETSAT GitLab.

## Original commit description

The conversion from picking coordinates to geographic coordinates
(longitude/latitude), reprojection to grid coordinates and finally to
grid indices performs 'round()' in the very last step.

This seems to be responsible for the half pixel offset as replacing that
by 'floor()' generates grid indices which do not show this half pixel
offset.

TODO: It has to be verified in the future, whether this fix is the right
one once the coordinate setup has been revised - now the display and the
picking matchi but the display itself still has a half pixel shift: MSG
grid point 1856, 1856 is not centered on the Nadir (0 deg E, 0 deg N),
but its upper left corner.