### PR TITLE
Fix all code style issues identified by flake8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+exclude: '^$'
+fail_fast: false
+repos:
+  #- repo: https://github.com/psf/black
+  #  rev: 20.8b1 # Replace by any tag/version: https://github.com/psf/black/tags
+  #  hooks:
+  #    - id: black
+  #      language_version: python3 # Should be a command that runs python3.6+
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.9.2
+    hooks:
+      - id: flake8
+        language_version: python3
+        additional_dependencies: [flake8-docstrings, flake8-debugger, flake8-bugbear]
+  #- repo: https://github.com/pycqa/isort
+  #  rev: 5.8.0
+  #  hooks:
+  #  - id: isort
+  #    language_version: python3

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ universal=1
 
 [flake8]
 max-line-length = 120
-ignore = E226,E241,E265,E266,W291,W293,W503,F999,E305,F405,W504
+ignore = D,D107,D202,E226,E241,E265,E266,W291,W293,W503,F999,E305,F405,W503,W504
 exclude =
     uwsift/ui
     uwsift/tests/timeline.py

--- a/uwsift/control/__init__.py
+++ b/uwsift/control/__init__.py
@@ -20,40 +20,6 @@ REQUIRES
 __author__ = 'rayg'
 __docformat__ = 'reStructuredText'
 
-import argparse
 import logging
-import sys
-import unittest
 
 LOG = logging.getLogger(__name__)
-
-
-def main():
-    parser = argparse.ArgumentParser(
-        description="PURPOSE",
-        epilog="",
-        fromfile_prefix_chars='@')
-    parser.add_argument('-v', '--verbose', dest='verbosity', action="count", default=0,
-                        help='each occurrence increases verbosity 1 level through ERROR-WARNING-Info-DEBUG')
-    # http://docs.python.org/2.7/library/argparse.html#nargs
-    # parser.add_argument('--stuff', nargs='5', dest='my_stuff',
-    #                    help="one or more random things")
-    parser.add_argument('pos_args', nargs='*',
-                        help="positional arguments don't have the '-' prefix")
-    args = parser.parse_args()
-
-    levels = [logging.ERROR, logging.WARN, logging.INFO, logging.DEBUG]
-    logging.basicConfig(level=levels[min(3, args.verbosity)])
-
-    if not args.pos_args:
-        unittest.main()
-        return 0
-
-    for pn in args.pos_args:
-        pass
-
-    return 0
-
-
-if __name__ == '__main__':
-    sys.exit(main())

--- a/uwsift/control/doc_ws_as_timeline_scene.py
+++ b/uwsift/control/doc_ws_as_timeline_scene.py
@@ -88,7 +88,7 @@ class SiftDocumentAsFramesInTracks(QFramesInTracksScene):
         """Remove QTrackItem and QFrameItem instances that no longer correspond to document content
         """
         LOG.debug("purging {} orphan tracks and {} orphan frames from timeline scene".format(len(tracks), len(frames)))
-        for frid in frames:
+        for _ in frames:
             self.removeItem()
         self._frame_items = dict((k, v) for (k, v) in self._frame_items.items() if k not in frames)
         self._track_items = dict((k, v) for (k, v) in self._track_items.items() if k not in tracks)

--- a/uwsift/control/file_behaviors.py
+++ b/uwsift/control/file_behaviors.py
@@ -20,16 +20,13 @@ REQUIRES
 __author__ = 'rayg'
 __docformat__ = 'reStructuredText'
 
-import argparse
 import logging
-import sys
-import unittest
 
 from PyQt5.QtCore import QObject
 
 # from PyQt4.QtGui import QAction
 
-
+LOG = logging.getLogger(__name__)
 FORMAT_GUIDEBOOK = {}
 
 
@@ -68,37 +65,3 @@ class UserAddsFileToDoc(QObject):
         :return:
         """
         pass
-
-
-LOG = logging.getLogger(__name__)
-
-
-def main():
-    parser = argparse.ArgumentParser(
-        description="PURPOSE",
-        epilog="",
-        fromfile_prefix_chars='@')
-    parser.add_argument('-v', '--verbose', dest='verbosity', action="count", default=0,
-                        help='each occurrence increases verbosity 1 level through ERROR-WARNING-Info-DEBUG')
-    # http://docs.python.org/2.7/library/argparse.html#nargs
-    # parser.add_argument('--stuff', nargs='5', dest='my_stuff',
-    #                    help="one or more random things")
-    parser.add_argument('pos_args', nargs='*',
-                        help="positional arguments don't have the '-' prefix")
-    args = parser.parse_args()
-
-    levels = [logging.ERROR, logging.WARN, logging.INFO, logging.DEBUG]
-    logging.basicConfig(level=levels[min(3, args.verbosity)])
-
-    if not args.pos_args:
-        unittest.main()
-        return 0
-
-    for pn in args.pos_args:
-        pass
-
-    return 0
-
-
-if __name__ == '__main__':
-    sys.exit(main())

--- a/uwsift/control/layer_tree.py
+++ b/uwsift/control/layer_tree.py
@@ -712,12 +712,14 @@ class LayerStackTreeViewModel(QAbstractItemModel):
             return True
         elif role == Qt.DisplayRole:
             if index.isValid():
-                LOG.debug("changing row {} name to {0!r:s}".format(index.row(), data))
+                LOG.debug("changing row {0} name to {1!r:s}".format(index.row(), data))
                 self.doc.change_layer_name(index.row(), data)
                 return True
         return False
 
-    def insertRows(self, row, count, parent=QModelIndex()):
+    def insertRows(self, row, count, parent=None):
+        if parent is None:
+            parent = QModelIndex()
         self.beginInsertRows(QModelIndex(), row, row + count - 1)
         LOG.debug(">>>> INSERT {} rows".format(count))
         # TODO: insert 'count' empty rows into document

--- a/uwsift/control/rgb_behaviors.py
+++ b/uwsift/control/rgb_behaviors.py
@@ -66,8 +66,8 @@ class UserModifiesRGBLayers(QObject):
                 families.append(None)
         self.create_rgb(families=families)
 
-    def create_rgb(self, action=None, families=[]):
-        if len(families) == 0:
+    def create_rgb(self, action=None, families=None):
+        if families is None or len(families) == 0:
             # get the layers to composite from current selection
             uuids = [u for u in self.layer_list_model.current_selected_uuids() if
                      self.doc[u][Info.KIND] in [Kind.IMAGE, Kind.COMPOSITE]]

--- a/uwsift/model/layer.py
+++ b/uwsift/model/layer.py
@@ -26,11 +26,8 @@ from uwsift.common import Info, Kind
 __author__ = 'rayg'
 __docformat__ = 'reStructuredText'
 
-import sys
 import logging
 import numpy as np
-import unittest
-import argparse
 
 LOG = logging.getLogger(__name__)
 
@@ -447,34 +444,3 @@ class DocAlgebraicLayer(DocCompositeLayer):
 #     """
 #     FUTURE: A shape layer which feeds probe values to another UI element or helper.
 #     """
-
-
-def main():
-    parser = argparse.ArgumentParser(
-        description="PURPOSE",
-        epilog="",
-        fromfile_prefix_chars='@')
-    parser.add_argument('-v', '--verbose', dest='verbosity', action="count", default=0,
-                        help='each occurrence increases verbosity 1 level through ERROR-WARNING-Info-DEBUG')
-    # http://docs.python.org/2.7/library/argparse.html#nargs
-    # parser.add_argument('--stuff', nargs='5', dest='my_stuff',
-    #                    help="one or more random things")
-    parser.add_argument('pos_args', nargs='*',
-                        help="positional arguments don't have the '-' prefix")
-    args = parser.parse_args()
-
-    levels = [logging.ERROR, logging.WARN, logging.INFO, logging.DEBUG]
-    logging.basicConfig(level=levels[min(3, args.verbosity)])
-
-    if not args.pos_args:
-        unittest.main()
-        return 0
-
-    for pn in args.pos_args:
-        pass
-
-    return 0
-
-
-if __name__ == '__main__':
-    sys.exit(main())

--- a/uwsift/project/geocat2merc.py
+++ b/uwsift/project/geocat2merc.py
@@ -166,8 +166,8 @@ def ahi_dataset_metadata(input_filename, dataset_name):
         metadata["valid_max"] = valid_max * scale_factor + add_offset
 
     # mimic satpy metadata
-    metadata["start_time"] = getattr(nc, "Image_Date_Time")
-    metadata["end_time"] = getattr(nc, "Image_Date_Time")
+    metadata["start_time"] = nc.Image_Date_Time
+    metadata["end_time"] = nc.Image_Date_Time
     if "standard_name" not in metadata:
         for k, v in VAR_NAME_STANDARD_NAME.items():
             if dataset_name.endswith(k):

--- a/uwsift/queue.py
+++ b/uwsift/queue.py
@@ -22,10 +22,7 @@ REQUIRES
 __author__ = 'rayg'
 __docformat__ = 'reStructuredText'
 
-import argparse
 import logging
-import sys
-import unittest
 from collections import OrderedDict
 
 from PyQt5.QtCore import QObject, pyqtSignal, QThread
@@ -211,34 +208,3 @@ def test_task():
         yield {TASK_DOING: 'test task', TASK_PROGRESS: float(dex) / 10.0}
         TheQueue.sleep(1)
     yield {TASK_DOING: 'test task', TASK_PROGRESS: 1.0}
-
-
-def main():
-    parser = argparse.ArgumentParser(
-        description="PURPOSE",
-        epilog="",
-        fromfile_prefix_chars='@')
-    parser.add_argument('-v', '--verbose', dest='verbosity', action="count", default=0,
-                        help='each occurrence increases verbosity 1 level through ERROR-WARNING-Info-DEBUG')
-    # http://docs.python.org/2.7/library/argparse.html#nargs
-    # parser.add_argument('--stuff', nargs='5', dest='my_stuff',
-    #                    help="one or more random things")
-    parser.add_argument('pos_args', nargs='*',
-                        help="positional arguments don't have the '-' prefix")
-    args = parser.parse_args()
-
-    levels = [logging.ERROR, logging.WARN, logging.INFO, logging.DEBUG]
-    logging.basicConfig(level=levels[min(3, args.verbosity)])
-
-    if not args.pos_args:
-        unittest.main()
-        return 0
-
-    for pn in args.pos_args:
-        pass
-
-    return 0
-
-
-if __name__ == '__main__':
-    sys.exit(main())

--- a/uwsift/tests/view/test_open_file_wizard.py
+++ b/uwsift/tests/view/test_open_file_wizard.py
@@ -86,7 +86,7 @@ def test_wizard_abi_l1b(qtbot, monkeypatch):
     # HACK: Bug in Windows, no enum's by name
     assert wiz.button(getattr(QWizard.WizardButton, 'NextButton', 1)).isEnabled()
     # Go to the next page
-    wiz.next()
+    wiz.next()  # noqa: B305
 
     ## Page 2
     # One product should be listed from our mocking above
@@ -98,7 +98,7 @@ def test_wizard_abi_l1b(qtbot, monkeypatch):
     # HACK: Bug in Windows, no enum's by name
     assert wiz.button(getattr(QWizard.WizardButton, 'FinishButton', 3)).isEnabled()
     # Go to the next page
-    wiz.next()
+    wiz.next()  # noqa: B305
 
     # Verify the wizard is left in a usable state for the MainWindow
     assert len(wiz.scenes) == 1

--- a/uwsift/tests/view/test_tile_calculator.py
+++ b/uwsift/tests/view/test_tile_calculator.py
@@ -75,7 +75,6 @@ def test_get_reference_points_bad_points(ic, iv):
     """Test that error is thrown if given invalid mesh points."""
     with pytest.raises(ValueError):
         get_reference_points(np.array(ic), np.array(iv))
-        assert False
 
 
 @pytest.mark.parametrize("cp,ip,num_p,mpp,exp", [
@@ -114,7 +113,6 @@ def test_calc_view_extents_bad_box(iebox, cp, ip, cs, dx, dy):
     """Test that error is thrown given zero-sized box."""
     with pytest.raises(ValueError):
         calc_view_extents(iebox, np.array(cp), np.array(ip), cs, dx, dy)
-        assert False
 
 
 @pytest.mark.parametrize("ims,ts,s,exp", [

--- a/uwsift/view/colormap.py
+++ b/uwsift/view/colormap.py
@@ -787,7 +787,7 @@ class ColormapManager(OrderedDict):
                 super(ColormapManager, self).__setitem__(k, v)
 
     def __iter__(self):
-        for cat, cat_dict in self._category_dict.items():
+        for cat_dict in self._category_dict.values():
             for cmap_name in cat_dict:
                 yield cmap_name
 
@@ -797,7 +797,7 @@ class ColormapManager(OrderedDict):
     def iter_colormaps(self, writeable_first=True):
         all_cmaps = [(self.is_writeable_colormap(name), name) for name in self]
         all_cmaps = sorted(all_cmaps, reverse=writeable_first)  # writeable first
-        for editable, cmap in all_cmaps:
+        for _, cmap in all_cmaps:
             try:
                 cmap_obj = self[cmap]
             except KeyError:
@@ -809,7 +809,7 @@ class ColormapManager(OrderedDict):
                 yield cmap
 
     def _files_for_dir(self, base_dir, recursive=True):
-        for subdir, dirs, files in os.walk(base_dir):
+        for subdir, _, files in os.walk(base_dir):
             for file_to_import in files:
                 nfp = os.path.join(subdir, file_to_import)
                 file_stem, file_ext = os.path.splitext(file_to_import)
@@ -873,7 +873,7 @@ class ColormapManager(OrderedDict):
         if category is not None:
             return self[category][cmap_name]
 
-        for cat, cat_dict in self.items():
+        for cat_dict in self.values():
             if cmap_name in cat_dict:
                 val = cat_dict[cmap_name]
                 self._cmap_cache[cmap_name] = val
@@ -906,7 +906,7 @@ class ColormapManager(OrderedDict):
 
     def __delitem__(self, key):
         super(ColormapManager, self).__delitem__(key)
-        for cat_name, cat_list in self._category_dict.items():
+        for cat_list in self._category_dict.values():
             try:
                 cat_list.remove(key)
             except ValueError:

--- a/uwsift/view/create_algebraic.py
+++ b/uwsift/view/create_algebraic.py
@@ -31,7 +31,7 @@ class CreateAlgebraicDialog(QtWidgets.QDialog):
         available_short_names = []
         selected_short_names = []
         # use DATASET_NAME as unique group identifier
-        for idx, prez, layer in self.doc.current_layers_where(kinds=(Kind.IMAGE, Kind.COMPOSITE)):
+        for _, _, layer in self.doc.current_layers_where(kinds=(Kind.IMAGE, Kind.COMPOSITE)):
             # use the UUID as a representative when talking to the document
             available_info.setdefault(layer[Info.SHORT_NAME],
                                       layer[Info.UUID])

--- a/uwsift/view/export_image.py
+++ b/uwsift/view/export_image.py
@@ -419,7 +419,7 @@ class ExportImageHelper(QtCore.QObject):
 
         for filename, file_images in filenames:
             writer = imageio.get_writer(filename, format_name, **params)
-            for u, x in file_images:
+            for _, x in file_images:
                 writer.append_data(numpy.array(x))
 
         writer.close()

--- a/uwsift/view/rgb_config.py
+++ b/uwsift/view/rgb_config.py
@@ -396,6 +396,6 @@ class RGBLayerConfigPane(QObject):
                 sbox.setDisabled(recipe.input_ids[idx] is None)
                 sbox.setValue(recipe.gammas[idx])
         else:
-            for idx, sbox in enumerate(self.gamma_boxes):
+            for sbox in self.gamma_boxes:
                 sbox.setDisabled(True)
                 sbox.setValue(1.)

--- a/uwsift/view/texture_atlas.py
+++ b/uwsift/view/texture_atlas.py
@@ -169,7 +169,7 @@ class MultiChannelGPUScaledTexture2D:
 
     @interpolation.setter
     def interpolation(self, value):
-        for tex in self._textures:
+        for _ in self._textures:
             self._texture.interpolation = value
 
     def check_data_format(self, data_arrays):

--- a/uwsift/view/tile_calculator.py
+++ b/uwsift/view/tile_calculator.py
@@ -539,7 +539,7 @@ class TileCalculator(object):
         # maximum stride that we shouldn't lower resolution beyond
         self.overview_stride = self.calc_overview_stride()
 
-    def visible_tiles(self, visible_geom, stride=Point(1, 1), extra_tiles_box=Box(0, 0, 0, 0)) -> Box:
+    def visible_tiles(self, visible_geom, stride=None, extra_tiles_box=None) -> Box:
         """
         given a visible world geometry and sampling, return (sampling-state, [Box-of-tiles-to-draw])
         sampling state is WELLSAMPLED/OVERSAMPLED/UNDERSAMPLED
@@ -547,6 +547,10 @@ class TileCalculator(object):
         tiles are specified as (iy,ix) integer pairs
         extra_box value says how many extra tiles to include around each edge
         """
+        if stride is None:
+            stride = Point(1, 1)
+        if extra_tiles_box is None:
+            extra_tiles_box = Box(0, 0, 0, 0)
         v = visible_geom
         e = extra_tiles_box
         return visible_tiles(

--- a/uwsift/view/timeline/common.py
+++ b/uwsift/view/timeline/common.py
@@ -113,7 +113,7 @@ class CoordTransform(QObject):
         self._time_base = new_settings.t
         self._time_unit = new_settings.d
 
-    def __init__(self, time_base: datetime = None, time_unit: timedelta = timedelta(seconds=1), track_height=None):
+    def __init__(self, time_base: datetime = None, time_unit: timedelta = None, track_height=None):
         """
 
         Args:
@@ -121,6 +121,8 @@ class CoordTransform(QObject):
             time_unit: time width corresponding to delta-X=1.0, defaults to 1.0s
             track_height: pixels high to display individual ttracks
         """
+        if time_unit is None:
+            time_unit = timedelta(seconds=1)
         super(CoordTransform, self).__init__()
         self._time_base = time_base or datetime.utcnow()
         self._time_unit = time_unit

--- a/uwsift/view/timeline/scene.py
+++ b/uwsift/view/timeline/scene.py
@@ -622,7 +622,7 @@ def _debug(type, value, tb):
         sys.__excepthook__(type, value, tb)
     else:
         import traceback
-        import pdb
+        import pdb  # noqa
         traceback.print_exception(type, value, tb)
         # …then start the debugger in post-mortem mode.
         pdb.post_mortem(tb)  # more “modern”

--- a/uwsift/view/visuals.py
+++ b/uwsift/view/visuals.py
@@ -882,12 +882,12 @@ class ShapefileLinesVisual(LineVisual):
         # Prepare the arrays
         total_points = 0
         total_parts = 0
-        for idx, one_shape in enumerate(self.sf.iterShapes()):
+        for one_shape in self.sf.iterShapes():
             total_points += len(one_shape.points)
             total_parts += len(one_shape.parts)
         vertex_buffer = np.empty((total_points * 2 - total_parts * 2, 2), dtype=np.float32)
         prev_idx = 0
-        for idx, one_shape in enumerate(self.sf.iterShapes()):
+        for one_shape in self.sf.iterShapes():
             # end_idx = prev_idx + len(one_shape.points) * 2 - len(one_shape.parts) * 2
             # vertex_buffer[prev_idx:end_idx:2] = one_shape.points[:-1]
             # for part_idx in one_shape.parts:

--- a/uwsift/workspace/collector.py
+++ b/uwsift/workspace/collector.py
@@ -108,7 +108,7 @@ class ResourceSearchPathCollector(QObject):
             if not os.path.isdir(path):
                 LOG.warning("{} is not a directory".format(path))
                 continue
-            for dirpath, dirnames, filenames in os.walk(path):
+            for dirpath, _, filenames in os.walk(path):
                 if self._is_posix and (os.stat(dirpath).st_mtime < last_checked):
                     skipped_dirs += 1
                     continue
@@ -173,7 +173,7 @@ class ResourceSearchPathCollector(QObject):
         for reader_and_files in readers_and_files:
             for reader_name, filenames in reader_and_files.items():
                 product_infos = self._ws.collect_product_metadata_for_paths(filenames, reader=reader_name)
-                for num_prods, product_info in product_infos:
+                for _, product_info in product_infos:
                     changed_uuids.add(product_info[Info.UUID])
                     num_seen += len(filenames)
                     status = {TASK_DOING: 'collecting metadata {}/{}'.format(num_seen, ntodo),
@@ -187,12 +187,12 @@ class ResourceSearchPathCollector(QObject):
 
 
 def _debug(type, value, tb):
-    "enable with sys.excepthook = debug"
+    """Enable with sys.excepthook = debug."""
     if not sys.stdin.isatty():
         sys.__excepthook__(type, value, tb)
     else:
         import traceback
-        import pdb
+        import pdb  # noqa
         traceback.print_exception(type, value, tb)
         # …then start the debugger in post-mortem mode.
         pdb.post_mortem(tb)  # more “modern”

--- a/uwsift/workspace/matrix.py
+++ b/uwsift/workspace/matrix.py
@@ -38,11 +38,7 @@ REQUIRES
 __author__ = 'rayg'
 __docformat__ = 'reStructuredText'
 
-import argparse
 import logging
-import os
-import sys
-import unittest
 from collections import namedtuple
 from datetime import timedelta
 from enum import Enum
@@ -83,9 +79,6 @@ class DataAdjacencyMatrix(QObject):
     - manages default presentation on a per-product basis
     - allows re-ordering of products, resulting in z-order scenegraph changes
     """
-
-    def __init__(self, initial_search_paths=[]):
-        super(DataAdjacencyMatrix, self).__init__()
 
     def add_search_paths(self, *paths):
         pass
@@ -130,61 +123,3 @@ class DataAdjacencyMatrix(QObject):
         :param do_signal: whether or not to propagate a Qt refresh signal
         :return: True if dimensionality changed
         """
-
-
-class tests(unittest.TestCase):
-    data_file = os.environ.get('TEST_DATA', os.path.expanduser("~/Data/test_files/thing.dat"))
-
-    def setUp(self):
-        pass
-
-    def test_something(self):
-        pass
-
-
-def _debug(type, value, tb):
-    "enable with sys.excepthook = debug"
-    if not sys.stdin.isatty():
-        sys.__excepthook__(type, value, tb)
-    else:
-        import traceback
-        import pdb
-        traceback.print_exception(type, value, tb)
-        # …then start the debugger in post-mortem mode.
-        pdb.post_mortem(tb)  # more “modern”
-
-
-def main():
-    parser = argparse.ArgumentParser(
-        description="PURPOSE",
-        epilog="",
-        fromfile_prefix_chars='@')
-    parser.add_argument('-v', '--verbose', dest='verbosity', action="count", default=0,
-                        help='each occurrence increases verbosity 1 level through ERROR-WARNING-Info-DEBUG')
-    parser.add_argument('-d', '--debug', dest='debug', action='store_true',
-                        help="enable interactive PDB debugger on exception")
-    # http://docs.python.org/2.7/library/argparse.html#nargs
-    # parser.add_argument('--stuff', nargs='5', dest='my_stuff',
-    #                    help="one or more random things")
-    parser.add_argument('inputs', nargs='*',
-                        help="input files to process")
-    args = parser.parse_args()
-
-    levels = [logging.ERROR, logging.WARN, logging.INFO, logging.DEBUG]
-    logging.basicConfig(level=levels[min(3, args.verbosity)])
-
-    if args.debug:
-        sys.excepthook = _debug
-
-    if not args.inputs:
-        unittest.main()
-        return 0
-
-    for pn in args.inputs:
-        pass
-
-    return 0
-
-
-if __name__ == '__main__':
-    sys.exit(main())

--- a/uwsift/workspace/metadatabase.py
+++ b/uwsift/workspace/metadatabase.py
@@ -886,7 +886,7 @@ def _debug(type, value, tb):
         sys.__excepthook__(type, value, tb)
     else:
         import traceback
-        import pdb
+        import pdb  # noqa
         traceback.print_exception(type, value, tb)
         # …then start the debugger in post-mortem mode.
         pdb.post_mortem(tb)  # more “modern”
@@ -918,9 +918,6 @@ def main():
 
     levels = [logging.ERROR, logging.WARN, logging.INFO, logging.DEBUG]
     logging.basicConfig(level=levels[min(3, args.verbosity)])
-
-    for pn in args.inputs:
-        pass
 
     return 0
 


### PR DESCRIPTION
While working on CI stuff I added automatic linting of the code. This found a lot of issues. You can run it locally with:

```bash
pip install flake8 flake8-debugger flake8-bugbear
flake8 uwsift
```

This PR fixes all the issues that were found. It also adds a pre-commit config which you can use by doing:

```bash
pip install pre-commit
pre-commit install
```

With this, linting is automatically done when you make a commit and if it finds anything you won't be able to commit until you fix the issues.

The config is relatively limited right now for a couple reasons:

1. I usually use the "black" autoformatter but didn't want to for SIFT until we've combined the EUMETSAT code more thoroughly since it is going to cause unnecessarily difficult merge conflicts.
2. I usually have "isort" for sorting imports automatically. Didn't do it for the same reason as not using black.
3. I disabled checking docstrings with `flake8-docstrings` since it would take years to update all the docstrings in SIFT. I've disabled checking them by including `ignore = D,` in the `setup.cfg` under the `flake8` section.
