### PR TITLE
Update color limit sliders to update display instantly

### DIFF
--- a/uwsift/tests/view/test_colormap_dialogs.py
+++ b/uwsift/tests/view/test_colormap_dialogs.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Test changes through the colormap dialog."""
+from uwsift.common import Info, Kind, Presentation
+from uwsift.model.layer import DocBasicLayer
+from uwsift.view.colormap_dialogs import ChangeColormapDialog
+from unittest import mock
+
+
+def test_slider_change(qtbot):
+    doc = mock.MagicMock()
+    prez = Presentation(
+        uuid="some_uuid",
+        kind=Kind.IMAGE,
+        visible=True,
+        a_order=0,
+        colormap="viridis",
+        climits=(0.0, 50.0),
+        gamma=1.0,
+        mixing=None,
+    )
+    layer_info = {
+        Info.VALID_RANGE: (0.0, 150.0),
+        Info.KIND: Kind.IMAGE,
+        Info.DISPLAY_FAMILY: "family1",
+        Info.SHORT_NAME: "some_name",
+        Info.UNIT_CONVERSION: (lambda x, inverse=False: x, lambda x, inverse=False: x),
+
+    }
+    layer = DocBasicLayer(doc, layer_info)
+    doc.prez_for_uuid.return_value = prez
+    doc.valid_range_for_uuid.return_value = layer_info[Info.VALID_RANGE]
+    doc.__getitem__.return_value = layer
+    widget = ChangeColormapDialog(doc, "some_uuid")
+
+    # Set the red min value manually
+    widget.ui.vmin_slider.setValue(8)
+    doc.change_clims_for_siblings.assert_called_once()
+    doc.change_clims_for_siblings.assert_called_with("some_uuid", (12.0, 50.0))

--- a/uwsift/tests/view/test_rgb_config.py
+++ b/uwsift/tests/view/test_rgb_config.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Test RGB configuration changes through the UI."""
+from uwsift.common import Info, Kind
+from uwsift.model.composite_recipes import CompositeRecipe
+from uwsift.view.rgb_config import RGBLayerConfigPane
+from uwsift.ui.pov_main_ui import Ui_MainWindow
+
+from PyQt5.QtWidgets import QMainWindow
+from PyQt5.QtCore import QPoint, Qt
+
+
+class _PaneWrapper(QMainWindow):
+    def __init__(self):
+        super().__init__()
+        self.ui = Ui_MainWindow()
+        self.ui.setupUi(self)
+        self.pane = RGBLayerConfigPane(self.ui, self.ui.layersPaneWidget)
+
+
+def test_slider_change(qtbot):
+    widget = _PaneWrapper()
+    pane = widget.pane
+
+    pane.family_added("family1", {
+        Info.VALID_RANGE: (0.0, 150.0),
+        Info.KIND: Kind.IMAGE,
+        Info.DISPLAY_FAMILY: "family1",
+        Info.UNIT_CONVERSION: (lambda x, inverse=False: x, lambda x, inverse=False: x),
+    })
+    pane.family_added("family2", {
+        Info.VALID_RANGE: (0.0, 150.0),
+        Info.KIND: Kind.IMAGE,
+        Info.DISPLAY_FAMILY: "family2",
+        Info.UNIT_CONVERSION: (lambda x, inverse=False: x, lambda x, inverse=False: x),
+    })
+    rgb_recipe = CompositeRecipe("my_rgb",
+                                 input_ids=["family1", "family2", None],
+                                 color_limits=((0.0, 90.0), (0.0, 90.0), (None, None)))
+    pane.selection_did_change(rgb_recipe)
+
+    # Set the red min value manually
+    with qtbot.waitSignal(pane.didChangeRGBComponentLimits) as blocker:
+        pane.sliders[0][0].setValue(8)
+    recipe = blocker.args[0]
+    clims_r = blocker.args[1][0]
+    clims_g = blocker.args[1][1]
+    clims_b = blocker.args[1][2]
+    assert recipe is rgb_recipe
+    assert clims_r == ((8.0 / 100.0) * 150, 90.0)
+    assert clims_g == (0.0, 90.0)
+    assert clims_b == (None, None)

--- a/uwsift/tests/view/test_rgb_config.py
+++ b/uwsift/tests/view/test_rgb_config.py
@@ -7,7 +7,6 @@ from uwsift.view.rgb_config import RGBLayerConfigPane
 from uwsift.ui.pov_main_ui import Ui_MainWindow
 
 from PyQt5.QtWidgets import QMainWindow
-from PyQt5.QtCore import QPoint, Qt
 
 
 class _PaneWrapper(QMainWindow):

--- a/uwsift/view/colormap_dialogs.py
+++ b/uwsift/view/colormap_dialogs.py
@@ -1,7 +1,6 @@
 import logging
-from PyQt5 import QtCore, QtGui, QtWidgets
+from PyQt5 import QtGui, QtWidgets
 from functools import partial
-from uuid import UUID
 
 from uwsift.common import Info, Kind
 from uwsift.ui.change_colormap_dialog_ui import Ui_changeColormapDialog

--- a/uwsift/view/colormap_dialogs.py
+++ b/uwsift/view/colormap_dialogs.py
@@ -10,7 +10,6 @@ LOG = logging.getLogger(__name__)
 
 
 class ChangeColormapDialog(QtWidgets.QDialog):
-    userDidChangeColorLimits = QtCore.pyqtSignal(UUID, tuple)  # layer being changed, char from 'rgba', new-min, new-max
 
     def __init__(self, doc, uuid, parent=None):
         super(ChangeColormapDialog, self).__init__(parent)

--- a/uwsift/view/colormap_dialogs.py
+++ b/uwsift/view/colormap_dialogs.py
@@ -50,8 +50,8 @@ class ChangeColormapDialog(QtWidgets.QDialog):
         self.ui.buttons.rejected.disconnect()
 
         self.ui.cmap_combobox.currentIndexChanged.connect(self._cmap_changed)
-        self.ui.vmin_slider.sliderReleased.connect(partial(self._slider_changed, is_max=False))
-        self.ui.vmax_slider.sliderReleased.connect(partial(self._slider_changed, is_max=True))
+        self.ui.vmin_slider.valueChanged.connect(partial(self._slider_changed, is_max=False))
+        self.ui.vmax_slider.valueChanged.connect(partial(self._slider_changed, is_max=True))
         self.ui.vmin_edit.editingFinished.connect(partial(self._edit_changed, is_max=False))
         self.ui.vmax_edit.editingFinished.connect(partial(self._edit_changed, is_max=True))
 
@@ -85,15 +85,16 @@ class ChangeColormapDialog(QtWidgets.QDialog):
             self._current_clims = (val, self._current_clims[1])
         self.doc.change_clims_for_siblings(self.uuid, self._current_clims)
 
-    def _slider_changed(self, is_max=True):
-        slider = self.ui.vmax_slider if is_max else self.ui.vmin_slider
+    def _slider_changed(self, value=None, is_max=True):
         edit = self.ui.vmax_edit if is_max else self.ui.vmin_edit
-
-        val = self._get_slider_value(slider.value())
-        LOG.debug('slider %s %s => %f' % (self.uuid, 'max' if is_max else 'min', val))
-        display_val = self.doc[self.uuid][Info.UNIT_CONVERSION][1](val)
+        if value is None:
+            slider = self.ui.vmax_slider if is_max else self.ui.vmin_slider
+            value = slider.value()
+        value = self._get_slider_value(value)
+        LOG.debug('slider %s %s => %f' % (self.uuid, 'max' if is_max else 'min', value))
+        display_val = self.doc[self.uuid][Info.UNIT_CONVERSION][1](value)
         edit.setText('{:0.03f}'.format(display_val))
-        return self._set_new_clims(val, is_max)
+        return self._set_new_clims(value, is_max)
 
     def _edit_changed(self, is_max=True):
         slider = self.ui.vmax_slider if is_max else self.ui.vmin_slider

--- a/uwsift/view/rgb_config.py
+++ b/uwsift/view/rgb_config.py
@@ -36,8 +36,7 @@ class RGBLayerConfigPane(QObject):
     def __init__(self, ui, parent):
         super(RGBLayerConfigPane, self).__init__(parent)
         self.ui = ui
-        self._valid_ranges = [None, None, None]
-        self._selected_family = [None, None, None]
+        self._valid_ranges = [(None, None), (None, None), (None, None)]
         self._families = {}
         self.recipe = None
 
@@ -51,11 +50,17 @@ class RGBLayerConfigPane(QObject):
 
         self._double_validator = qdoba = QDoubleValidator()
         self.ui.editMinRed.setValidator(qdoba)
+        self.ui.editMinRed.setText("0.0")
         self.ui.editMaxRed.setValidator(qdoba)
+        self.ui.editMaxRed.setText("0.0")
         self.ui.editMinGreen.setValidator(qdoba)
+        self.ui.editMinGreen.setText("0.0")
         self.ui.editMaxGreen.setValidator(qdoba)
+        self.ui.editMaxGreen.setText("0.0")
         self.ui.editMinBlue.setValidator(qdoba)
+        self.ui.editMinBlue.setText("0.0")
         self.ui.editMaxBlue.setValidator(qdoba)
+        self.ui.editMaxBlue.setText("0.0")
 
         [x.currentIndexChanged.connect(partial(self._combo_changed, combo=x, color=rgb))
          for rgb, x in zip(('b', 'g', 'r'), (self.ui.comboBlue, self.ui.comboGreen, self.ui.comboRed))]
@@ -306,7 +311,7 @@ class RGBLayerConfigPane(QObject):
                 "Could not find {} in families {}".format(repr(family), repr(list(sorted(self._families.keys())))))
         if clims is None or clims == (None, None) or \
                 family not in self._families:
-            self._valid_ranges[idx] = None
+            self._valid_ranges[idx] = (None, None)
             slider[0].setSliderPosition(0)
             slider[1].setSliderPosition(0)
             editn.setText('0.0')

--- a/uwsift/view/scene_graph.py
+++ b/uwsift/view/scene_graph.py
@@ -905,12 +905,12 @@ class SceneGraphManager(QObject):
 
     def change_layers_color_limits(self, change_dict):
         for uuid, clims in change_dict.items():
-            LOG.info('changing {} to color limits {}'.format(uuid, clims))
+            LOG.debug('changing {} to color limits {}'.format(uuid, clims))
             self.set_color_limits(clims, uuid)
 
     def change_layers_gamma(self, change_dict):
         for uuid, gamma in change_dict.items():
-            LOG.info('changing {} to gamma {}'.format(uuid, gamma))
+            LOG.debug('changing {} to gamma {}'.format(uuid, gamma))
             self.set_gamma(gamma, uuid)
 
     def change_layers_image_kind(self, change_dict):


### PR DESCRIPTION
Closes #323 

Turns out I implemented the previous way on purpose to avoid over taxing the CPU/GPU to draw the updates. However, looks like it handles this just fine. This PR updates the color limit sliders for the individual layers and for the RGB layers so that scrolling or clicking somewhere on the slider range will automatically the visual. Previously this required clicking and releasing the handle on the slider.