### PR TITLE
Fix GOES-18 platform not being recognized properly

### DIFF
--- a/uwsift/common.py
+++ b/uwsift/common.py
@@ -210,6 +210,7 @@ class Platform(Enum):
     GOES_16 = 'G16'
     GOES_17 = 'G17'
     GOES_18 = 'G18'
+    GOES_19 = 'G19'
     NWP = 'NWP'
     MSG8 = 'Meteosat-8'
     MSG9 = 'Meteosat-9'
@@ -224,6 +225,7 @@ PLATFORM_MAP['h9'] = Platform.HIMAWARI_9
 PLATFORM_MAP['goes16'] = Platform.GOES_16
 PLATFORM_MAP['goes17'] = Platform.GOES_17
 PLATFORM_MAP['goes18'] = Platform.GOES_18
+PLATFORM_MAP['goes19'] = Platform.GOES_19
 
 
 class Info(Enum):

--- a/uwsift/workspace/guidebook.py
+++ b/uwsift/workspace/guidebook.py
@@ -110,6 +110,8 @@ NOMINAL_WAVELENGTHS = {
 
     Platform.GOES_16: _NW_GOESR_ABI,
     Platform.GOES_17: _NW_GOESR_ABI,
+    Platform.GOES_18: _NW_GOESR_ABI,
+    Platform.GOES_19: _NW_GOESR_ABI,
 }
 
 # CF compliant Standard Names (should be provided by input files or the workspace)

--- a/uwsift/workspace/importer.py
+++ b/uwsift/workspace/importer.py
@@ -50,6 +50,8 @@ DEFAULT_GUIDEBOOK = ABI_AHI_Guidebook
 GUIDEBOOKS = {
     Platform.GOES_16: ABI_AHI_Guidebook,
     Platform.GOES_17: ABI_AHI_Guidebook,
+    Platform.GOES_18: ABI_AHI_Guidebook,
+    Platform.GOES_19: ABI_AHI_Guidebook,
     Platform.HIMAWARI_8: ABI_AHI_Guidebook,
     Platform.HIMAWARI_9: ABI_AHI_Guidebook,
 }
@@ -674,6 +676,8 @@ class GeoTiffImporter(aSingleFileWithSingleProductImporter):
 PLATFORM_ID_TO_PLATFORM = {
     'G16': Platform.GOES_16,
     'G17': Platform.GOES_17,
+    'G18': Platform.GOES_18,
+    'G19': Platform.GOES_19,
     # hsd2nc export of AHI data as PUG format
     'Himawari-8': Platform.HIMAWARI_8,
     'Himawari-9': Platform.HIMAWARI_9,
@@ -1022,7 +1026,7 @@ class SatpyImporter(aImporter):
     def _get_platform_instrument(attrs: dict):
         """Convert SatPy platform_name/sensor to """
         attrs[Info.INSTRUMENT] = attrs.get('sensor')
-        attrs[Info.PLATFORM] = attrs.get('platform_name')
+        attrs[Info.PLATFORM] = attrs.get('platform_name') or attrs.get('platform_shortname')
 
         # Special handling of GRIB forecast data
         if 'centreDescription' in attrs and \


### PR DESCRIPTION
Closes #325 

Satpy has a bug in it that doesn't properly assign `platform_name` in the metadata it returns for GOES-18 data. SIFT was solely using this metadata to determine its internal representation of the platform. Since it wasn't setup properly it was resulting in an "UNKNOWN" platform ("???" in the UI) being assigned to all GOES-18 data.

This PR fixes this by also looking at `platform_shortname`. This means that it should recognize G18 data immediately without the future Satpy fix that I'm working on.