### PR TITLE
Fix compatibility with vispy 0.8.0+

### DIFF
--- a/uwsift/view/rgb_config.py
+++ b/uwsift/view/rgb_config.py
@@ -64,10 +64,6 @@ class RGBLayerConfigPane(QObject):
 
         [x.currentIndexChanged.connect(partial(self._combo_changed, combo=x, color=rgb))
          for rgb, x in zip(('b', 'g', 'r'), (self.ui.comboBlue, self.ui.comboGreen, self.ui.comboRed))]
-        # [x.sliderReleased.connect(partial(self._slider_changed, slider=x, color=rgb, is_max=False))
-        #  for rgb, x in zip(('b', 'g', 'r'), (self.ui.slideMinBlue, self.ui.slideMinGreen, self.ui.slideMinRed))]
-        # [x.sliderReleased.connect(partial(self._slider_changed, slider=x, color=rgb, is_max=True))
-        #  for rgb, x in zip(('b', 'g', 'r'), (self.ui.slideMaxBlue, self.ui.slideMaxGreen, self.ui.slideMaxRed))]
         [x.valueChanged.connect(partial(self._slider_changed, slider=x, color=rgb, is_max=False))
          for rgb, x in zip(('b', 'g', 'r'), (self.ui.slideMinBlue, self.ui.slideMinGreen, self.ui.slideMinRed))]
         [x.valueChanged.connect(partial(self._slider_changed, slider=x, color=rgb, is_max=True))
@@ -329,18 +325,28 @@ class RGBLayerConfigPane(QObject):
             valid_range = self._families[family][Info.VALID_RANGE]
             self._valid_ranges[idx] = valid_range
 
+            # block signals so the changed sliders don't trigger updates
+            slider[0].blockSignals(True)
+            slider[1].blockSignals(True)
             slider_val = self._create_slider_value(valid_range[0], valid_range[1], clims[0])
             slider[0].setSliderPosition(max(slider_val, 0))
             slider_val = self._create_slider_value(valid_range[0], valid_range[1], clims[1])
             slider[1].setSliderPosition(min(slider_val, self._slider_steps))
+            slider[0].blockSignals(False)
+            slider[1].blockSignals(False)
+
             self._update_line_edits(color, *clims)
 
     def _set_minmax_sliders(self, recipe):
         if recipe:
+            print("Setting sliders with a recipe: ", recipe)
             for idx, (color, clim) in enumerate(zip("rgb", recipe.color_limits)):
                 family = recipe.input_ids[idx]
+                print("About to set individual slider for ", color, clim, family)
                 self._set_minmax_slider(color, family, clim)
+                print("done setting individual slider for ", color)
         else:
+            print("Setting sliders with no recipe")
             self._set_minmax_slider("r", None)
             self._set_minmax_slider("g", None)
             self._set_minmax_slider("b", None)

--- a/uwsift/view/visuals.py
+++ b/uwsift/view/visuals.py
@@ -628,6 +628,14 @@ class SIFTMultiChannelTiledGeolocatedMixin(SIFTTiledGeolocatedMixin):
         return new_data
 
 
+class _NoColormap:
+    """Placeholder colormap class to make MultiChannelImageVisual compatible with ImageVisual."""
+
+    def texture_lut(self):
+        """Get empty (None) colormap data."""
+        return None
+
+
 class MultiChannelImageVisual(ImageVisual):
     """Visual subclass displaying an image from three separate arrays.
 
@@ -665,9 +673,6 @@ class MultiChannelImageVisual(ImageVisual):
         and is hardcoded to ``r32f`` internal texture format.
 
     """
-
-    VERTEX_SHADER = ImageVisual.VERTEX_SHADER
-    FRAGMENT_SHADER = ImageVisual.FRAGMENT_SHADER
 
     def __init__(self, data_arrays, clim='auto', gamma=1.0, **kwargs):
         if kwargs.get("texture_format") is not None:
@@ -767,7 +772,7 @@ class MultiChannelImageVisual(ImageVisual):
     def cmap(self, cmap):
         if cmap is not None:
             raise ValueError("MultiChannelImageVisual does not support a colormap.")
-        self._cmap = None
+        self._cmap = _NoColormap()
 
     def _build_interpolation(self):
         # assumes 'nearest' interpolation


### PR DESCRIPTION
Fixes a few issues:

1. vispy 0.8.0 removed some if statements that allowed our RGB Visual to have `cmap = None`. I've replaced this with a placeholder for no colormap that returns `None` for the colormap texture data and results in the same outcome.
2. vispy 0.9.1 removed some global variables for shaders in ImageVisual, but we didn't actually need them here.
3. When I updated the sliders to update immediately in #324 I introduced a bug that set RGB limits to something other than what they should have been (essentially the min value was being set to near 0).