### PR TITLE
Fix Python 3.10 incompatibilities

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
         with:
           miniforge-variant: Mambaforge
           miniforge-version: latest
-          python-version: 3.9
+          python-version: 3.10
           use-mamba: true
           environment-file: continuous_integration/environment.yaml
           activate-environment: test-environment

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,6 +43,7 @@ jobs:
         with:
           miniforge-variant: Mambaforge
           miniforge-version: latest
+          python-version: 3.9
           use-mamba: true
           environment-file: continuous_integration/environment.yaml
           activate-environment: test-environment
@@ -109,6 +110,7 @@ jobs:
           miniforge-variant: Mambaforge
           miniforge-version: latest
           use-mamba: true
+          python-version: ${{ matrix.python-version }}
           environment-file: continuous_integration/environment.yaml
           activate-environment: test-environment
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
         with:
           miniforge-variant: Mambaforge
           miniforge-version: latest
-          python-version: 3.10
+          python-version: "3.10"
           use-mamba: true
           environment-file: continuous_integration/environment.yaml
           activate-environment: test-environment

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,7 +74,7 @@ jobs:
         # XXX: We don't currently have OpenGL installation on other platforms
         #os: ["windows-latest", "ubuntu-latest", "macos-latest"]
         os: ["ubuntu-latest"]
-        python-version: ["3.7", "3.9"]
+        python-version: ["3.7", "3.10"]
         experimental: [false]
         include:
           - python-version: "3.9"

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -54,6 +54,23 @@ autodoc_mock_imports = [
 seqdiag_fontpath = os.path.abspath('./source/fonts/DejaVuSerif.ttf')
 
 
+def _skip_pyqtsignal_doc(app, what, name, obj, skip, options):
+    # see https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#event-autodoc-skip-member
+    if what == "class" and "pyqtSignal" in obj.__class__.__name__:
+        return True
+    # fallback to other handlers or autodoc default
+    return None
+
+
+def setup(app):
+    """Global setup function for sphinx documentation.
+
+    Connect to autodoc event so invalid pyqtSignal docs can be skipped.
+
+    """
+    app.connect('autodoc-skip-member', _skip_pyqtsignal_doc)
+
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 
@@ -228,25 +245,25 @@ htmlhelp_basename = 'SIFTdoc'
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {
-# The paper size ('letterpaper' or 'a4paper').
-#'papersize': 'letterpaper',
+    # The paper size ('letterpaper' or 'a4paper').
+    #'papersize': 'letterpaper',
 
-# The font size ('10pt', '11pt' or '12pt').
-#'pointsize': '10pt',
+    # The font size ('10pt', '11pt' or '12pt').
+    #'pointsize': '10pt',
 
-# Additional stuff for the LaTeX preamble.
-#'preamble': '',
+    # Additional stuff for the LaTeX preamble.
+    #'preamble': '',
 
-# Latex figure (float) alignment
-#'figure_align': 'htbp',
+    # Latex figure (float) alignment
+    #'figure_align': 'htbp',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  (master_doc, 'SIFT.tex', 'SIFT Documentation',
-   'SIFT Developers', 'manual'),
+    (master_doc, 'SIFT.tex', 'SIFT Documentation',
+     'SIFT Developers', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -289,9 +306,9 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  (master_doc, 'SIFT', 'SIFT Documentation',
-   author, 'SIFT', 'One line description of project.',
-   'Miscellaneous'),
+    (master_doc, 'SIFT', 'SIFT Documentation',
+     author, 'SIFT', 'One line description of project.',
+     'Miscellaneous'),
 ]
 
 # Documents to append as an appendix to all manuals.

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ universal=1
 max-line-length = 120
 ignore = D,D107,D202,E226,E241,E265,E266,W291,W293,W503,F999,E305,F405,W503,W504
 exclude =
-    uwsift/ui
+    uwsift/ui/*.py
     uwsift/tests/timeline.py
 
 [coverage:run]

--- a/uwsift/__main__.py
+++ b/uwsift/__main__.py
@@ -718,7 +718,7 @@ class Main(QtWidgets.QMainWindow):
         self._init_key_releases()
 
         self.scheduler = QtCore.QTimer(parent=self)
-        self.scheduler.setInterval(200.0)
+        self.scheduler.setInterval(200)
         self.scheduler.timeout.connect(partial(self.scene_manager.on_view_change, self.scheduler))
 
         def start_wrapper(timer, event):

--- a/uwsift/control/layer_tree.py
+++ b/uwsift/control/layer_tree.py
@@ -124,7 +124,7 @@ class LayerWidgetDelegate(QStyledItemDelegate):
         bounds = painter.drawText(rect.left() + LEFT_OFFSET,
                                   rect.top() + TOP_OFFSET,
                                   rect.width() - LEFT_OFFSET,
-                                  CELL_HEIGHT / 2 - TOP_OFFSET,
+                                  int(CELL_HEIGHT / 2 - TOP_OFFSET),
                                   Qt.AlignLeft,
                                   text,
                                   )
@@ -135,7 +135,7 @@ class LayerWidgetDelegate(QStyledItemDelegate):
             ao_rect = QRect(bounds.right(),
                             rect.top() + TOP_OFFSET,
                             rect.width() - bounds.right(),
-                            CELL_HEIGHT / 2 - TOP_OFFSET,
+                            int(CELL_HEIGHT / 2 - TOP_OFFSET),
                             )
             # draw the text once to get the bounding rectangle
             bounds = painter.drawText(ao_rect,

--- a/uwsift/model/document.py
+++ b/uwsift/model/document.py
@@ -61,7 +61,8 @@ __author__ = 'rayg'
 __docformat__ = 'reStructuredText'
 
 import logging
-from collections import MutableSequence, OrderedDict, defaultdict
+from collections import OrderedDict, defaultdict
+from collections.abc import MutableSequence
 from itertools import groupby, chain
 from uuid import UUID, uuid1 as uuidgen
 from datetime import datetime, timedelta

--- a/uwsift/ui/create_algebraic_dialog_ui.py
+++ b/uwsift/ui/create_algebraic_dialog_ui.py
@@ -42,7 +42,7 @@ class Ui_create_algebraic_dialog(object):
         self.formLayout.setFormAlignment(QtCore.Qt.AlignLeading | QtCore.Qt.AlignLeft | QtCore.Qt.AlignTop)
         self.formLayout.setObjectName("formLayout")
         self.name_label = QtWidgets.QLabel(self.formLayoutWidget)
-        self.name_label.setAlignment(QtCore.Qt.AlignLeading | QtCore.Qt.AlignLeft | QtCore.Qt.AlignVCenter)
+        self.name_label.setAlignment(int(QtCore.Qt.AlignLeading | QtCore.Qt.AlignLeft | QtCore.Qt.AlignVCenter))
         self.name_label.setObjectName("name_label")
         self.formLayout.setWidget(0, QtWidgets.QFormLayout.LabelRole, self.name_label)
         self.layer_name_edit = QtWidgets.QLineEdit(self.formLayoutWidget)

--- a/uwsift/ui/export_image_dialog_ui.py
+++ b/uwsift/ui/export_image_dialog_ui.py
@@ -28,7 +28,7 @@ class Ui_ExportImageDialog(object):
         self.buttonBox.setObjectName("buttonBox")
         self.frameRangeGroupBox = QtWidgets.QGroupBox(ExportImageDialog)
         self.frameRangeGroupBox.setGeometry(QtCore.QRect(10, 30, 251, 111))
-        self.frameRangeGroupBox.setAlignment(QtCore.Qt.AlignLeading | QtCore.Qt.AlignLeft | QtCore.Qt.AlignTop)
+        self.frameRangeGroupBox.setAlignment(int(QtCore.Qt.AlignLeading | QtCore.Qt.AlignLeft | QtCore.Qt.AlignTop))
         self.frameRangeGroupBox.setFlat(False)
         self.frameRangeGroupBox.setCheckable(False)
         self.frameRangeGroupBox.setObjectName("frameRangeGroupBox")

--- a/uwsift/view/colormap_dialogs.py
+++ b/uwsift/view/colormap_dialogs.py
@@ -120,7 +120,7 @@ class ChangeColormapDialog(QtWidgets.QDialog):
         return (slider_val / self._slider_steps) * (self.valid_max - self.valid_min) + self.valid_min
 
     def _create_slider_value(self, channel_val):
-        return ((channel_val - self.valid_min) / (self.valid_max - self.valid_min)) * self._slider_steps
+        return int((channel_val - self.valid_min) / (self.valid_max - self.valid_min)) * self._slider_steps
 
     def _init_vmin_slider(self):
         current_vmin = self._initial_clims[0]

--- a/uwsift/view/rgb_config.py
+++ b/uwsift/view/rgb_config.py
@@ -171,7 +171,7 @@ class RGBLayerConfigPane(QObject):
         return (slider_val / self._slider_steps) * (valid_max - valid_min) + valid_min
 
     def _create_slider_value(self, valid_min, valid_max, channel_val):
-        return ((channel_val - valid_min) / (valid_max - valid_min)) * self._slider_steps
+        return int((channel_val - valid_min) / (valid_max - valid_min)) * self._slider_steps
 
     def _min_max_for_color(self, rgba: str):
         """

--- a/uwsift/view/timeline/scene.py
+++ b/uwsift/view/timeline/scene.py
@@ -164,6 +164,7 @@ class QFramesInTracksScene(QGraphicsScene):
         pass
 
     def sceneRectChanged(self, new_rect: QRectF):
+        """Update tracks when scene rect changes."""
         self._align_tracks_to_scene_rect(new_rect, False)
         super(QFramesInTracksScene, self).sceneRectChanged(new_rect)
 

--- a/uwsift/workspace/metadatabase.py
+++ b/uwsift/workspace/metadatabase.py
@@ -40,7 +40,8 @@ import logging
 import os
 import sys
 import unittest
-from collections import MutableMapping, defaultdict
+from collections import defaultdict
+from collections.abc import MutableMapping
 from datetime import datetime
 from functools import reduce
 from uuid import UUID

--- a/uwsift/workspace/workspace.py
+++ b/uwsift/workspace/workspace.py
@@ -40,7 +40,8 @@ FUTURE import sequence:
 import logging
 import os
 import shutil
-from collections import Mapping as ReadOnlyMapping, defaultdict, OrderedDict
+from collections import defaultdict, OrderedDict
+from collections.abc import Mapping as ReadOnlyMapping
 from datetime import datetime, timedelta
 from typing import Mapping, Generator, Tuple, Dict
 from uuid import UUID, uuid1 as uuidgen


### PR DESCRIPTION
A number of python 3.10 gotchas including library location changes, type markup, Qt call signature types, float vs integer division prevent SIFT from starting up when using python 3.10. 