### PR TITLE
Update CI to run Python 3.10

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,7 +73,7 @@ jobs:
         # XXX: We don't currently have OpenGL installation on other platforms
         #os: ["windows-latest", "ubuntu-latest", "macos-latest"]
         os: ["ubuntu-latest"]
-        python-version: ["3.7", "3.9"]
+        python-version: ["3.7", "3.10"]
         experimental: [false]
         include:
           - python-version: "3.9"


### PR DESCRIPTION
Related to #331. Let's see if our tests show that Python 3.10 fails.