### PR TITLE
Remove funcparserlib workaround to install new 1.0 release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,7 +52,6 @@ jobs:
         shell: bash -l {0}
         run: |
           pip install sphinx sphinx_rtd_theme sphinxcontrib-apidoc sphinxcontrib-seqdiag sphinxcontrib-blockdiag blockdiag
-          pip install -U --pre funcparserlib
           pip install --no-deps -e .
 
       - name: Run Sphinx Build


### PR DESCRIPTION
There was a bug between setuptools and old funcparserlib. A new version of funcparserlib has been released that fixes the problem. This removes the workaround that was in the CI job.