### PR TITLE
Fix prints to stdout with stderr or warnings or removal

### DIFF
--- a/uwsift/model/area_definitions_manager.py
+++ b/uwsift/model/area_definitions_manager.py
@@ -82,7 +82,6 @@ class AreaDefinitionsManager:
         for area_def in cls._available_area_defs_by_id.values():
             proj: str = area_def.proj_dict["proj"]
             if proj in ("latlon", "latlong", "lonlat", "longlat"):
-                print(f"FOUND {proj}")
                 return
 
         # Add default area definition(s)?

--- a/uwsift/view/scene_graph.py
+++ b/uwsift/view/scene_graph.py
@@ -782,7 +782,6 @@ class SceneGraphManager(QObject):
 
         for pixel in pixels:
             data[pixel["y"], pixel["x"]] = pixel["color"].value
-            print(f'{pixel["desc"]} ({pixel["color"].name}) -> x: {pixel["x"]} y: {pixel["y"]}')
 
         return data
 


### PR DESCRIPTION
We need to stop printing things to stdout, especially on initialization/GUI startup. Warnings should be used for warnings or as a last resort stderr should be used instead of stdout. Additionally, all on-import things in `uwsift/__init__.py` should really be moved to nearer to the argument parsing (GUI creation/startup). Similarly, access to config items should be done at use time not import time. These things are not fixed as part of this PR but FIXMEs were added.

CC @strandgren @ameraner 

For the record, I needed to remove these print messages because it was stopping me from doing bash things like `version=$(python -c "import uwsift; print(uwsift.__version__)")` which is used in the conda-pack build scripts.