### PR TITLE
Fix conda-pack builds on Windows

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -54,6 +54,8 @@ jobs:
 
       - name: Install SSH Key
         uses: shimataro/ssh-key-action@v2
+        # only upload on push (currently only master), otherwise SFTP key is not needed
+        if: github.event_name == 'push'
         with:
           key: ${{ secrets.SIFT_SFTP_UPLOAD_KEY }}
           name: id_rsa_sftp

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -6,6 +6,7 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  pull_request:
   push:
     branches:
       - master
@@ -83,6 +84,8 @@ jobs:
       # that would require uploading the bundles as artifacts which would
       # quickly hit our temporary storage limits
       - name: Upload bundle
+        # only upload on push (currently only master)
+        if: github.event_name == 'push'
         run: |
           continuous_integration/upload_conda_pack.sh
 

--- a/build_conda_pack.py
+++ b/build_conda_pack.py
@@ -72,12 +72,12 @@ def main():
 
     # HACK: https://github.com/conda/conda-pack/issues/141
     if sys.platform.startswith("win"):
-        with open(os.path.join(sys.prefix, "qt.conf"), "rt") as qtconf:
+        with open(os.path.join(sys.prefix, "bin", "qt.conf"), "rt") as qtconf:
             old_text = qtconf.read()
         (old_prefix,) = tuple(re.findall(r"^Prefix\s*=\s*(.*?).Library\s*$", old_text, re.MULTILINE))
         new_prefix = old_prefix.replace("/", "\\")
         new_text = old_text.replace(old_prefix, new_prefix)
-        with open(os.path.join(sys.prefix, "qt.conf"), "wt") as qtconf:
+        with open(os.path.join(sys.prefix, "bin", "qt.conf"), "wt") as qtconf:
             qtconf.write(new_text)
         with open(os.path.join(sys.prefix, "Library", "bin", "qt.conf"), "wt") as qtconf:
             qtconf.write(new_text)

--- a/build_conda_pack.py
+++ b/build_conda_pack.py
@@ -77,6 +77,8 @@ def main():
         (old_prefix,) = tuple(re.findall(r"^Prefix\s*=\s*(.*?).Library\s*$", old_text, re.MULTILINE))
         new_prefix = old_prefix.replace("/", "\\")
         new_text = old_text.replace(old_prefix, new_prefix)
+        with open(os.path.join(sys.prefix, "qt.conf"), "wt") as qtconf:
+            qtconf.write(new_text)
         with open(os.path.join(sys.prefix, "Library", "bin", "qt.conf"), "wt") as qtconf:
             qtconf.write(new_text)
 

--- a/build_conda_pack.py
+++ b/build_conda_pack.py
@@ -72,13 +72,11 @@ def main():
 
     # HACK: https://github.com/conda/conda-pack/issues/141
     if sys.platform.startswith("win"):
-        with open(os.path.join(sys.prefix, "bin", "qt.conf"), "rt") as qtconf:
+        with open(os.path.join(sys.prefix, "Library", "bin", "qt.conf"), "rt") as qtconf:
             old_text = qtconf.read()
         (old_prefix,) = tuple(re.findall(r"^Prefix\s*=\s*(.*?).Library\s*$", old_text, re.MULTILINE))
         new_prefix = old_prefix.replace("/", "\\")
         new_text = old_text.replace(old_prefix, new_prefix)
-        with open(os.path.join(sys.prefix, "bin", "qt.conf"), "wt") as qtconf:
-            qtconf.write(new_text)
         with open(os.path.join(sys.prefix, "Library", "bin", "qt.conf"), "wt") as qtconf:
             qtconf.write(new_text)
 

--- a/rtd_requirements.txt
+++ b/rtd_requirements.txt
@@ -8,3 +8,4 @@ pyproj
 sqlalchemy
 pyyaml
 appdirs
+setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
qt.conf seems to be in the "bin/" directory now