### PR TITLE
Fix export image and switch to imageio v3 API

### DIFF
--- a/continuous_integration/environment.yaml
+++ b/continuous_integration/environment.yaml
@@ -6,7 +6,7 @@ dependencies:
   - defusedxml
   - Cython
   - imageio
-  - imageio-ffmpeg
+  - av
   - matplotlib
   - numba
   - numpy

--- a/setup.py
+++ b/setup.py
@@ -202,6 +202,7 @@ setup(
         "donfig",
         "h5py",
         "imageio",
+        "av",
         "matplotlib",
         "netCDF4",
         "numba",

--- a/uwsift/tests/view/test_export_image.py
+++ b/uwsift/tests/view/test_export_image.py
@@ -187,7 +187,7 @@ def test_convert_frame_range(range, exp, window):
                 ],
             },
         ),
-        ({"fps": 1, "filename": "test.gif"}, {"fps": 1, "loop": 0}),
+        ({"fps": 1, "filename": "test.gif"}, {"duration": [1000.0, 1000.0], "loop": 0}),
         (
             {"fps": 1, "filename": "test.mp4"},
             {

--- a/uwsift/tests/view/test_export_image.py
+++ b/uwsift/tests/view/test_export_image.py
@@ -201,9 +201,6 @@ def test_convert_frame_range(range, exp, window):
                 "codec": "libx264",
                 "plugin": "pyav",
                 "in_pixel_format": "rgba",
-                "filter_sequence": [
-                    ("scale", "iw+gt(mod(iw,16), 0)*(16-mod(iw,16)):ih+gt(mod(ih,16), 0)*(16-mod(ih,16))"),
-                ],
             },
         ),
         ({"fps": 1, "filename": "test.gif"}, {"duration": [1000.0, 1000.0], "loop": 0}),
@@ -214,9 +211,6 @@ def test_convert_frame_range(range, exp, window):
                 "codec": "libx264",
                 "plugin": "pyav",
                 "in_pixel_format": "rgba",
-                "filter_sequence": [
-                    ("scale", "iw+gt(mod(iw,16), 0)*(16-mod(iw,16)):ih+gt(mod(ih,16), 0)*(16-mod(ih,16))"),
-                ],
             },
         ),
     ],
@@ -287,7 +281,7 @@ def test_save_screenshot_animations(fr, fn, overwrite, fps, monkeypatch, window,
         exp_frame_shape = (15, 20)
         read_kwargs = {"plugin": "pillow", "mode": "RGBA"}
     else:
-        exp_frame_shape = (480, 640)
+        exp_frame_shape = (14, 20)
         read_kwargs = {"plugin": "pyav"}
     frames = imageio.imread(fn, **read_kwargs)
     assert frames.shape[0] == (len(fr) if fr else 1)

--- a/uwsift/tests/view/test_export_image.py
+++ b/uwsift/tests/view/test_export_image.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 import os
 from typing import Any, Optional

--- a/uwsift/view/export_image.py
+++ b/uwsift/view/export_image.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import io
 import logging
 import os

--- a/uwsift/view/export_image.py
+++ b/uwsift/view/export_image.py
@@ -447,6 +447,8 @@ class ExportImageHelper(QtCore.QObject):
     def _write_images(self, filenames, params):
         for filename, file_images in filenames:
             images_arrays = [np.array(image) for _, image in file_images]
+            if filename.endswith(".jpg"):
+                images_arrays = [image_arr[:, :, :3] for image_arr in images_arrays]
             try:
                 imageio.imwrite(filename, images_arrays, **params)
             except IOError:

--- a/uwsift/view/export_image.py
+++ b/uwsift/view/export_image.py
@@ -30,7 +30,8 @@ PYAV_ANIMATION_PARAMS = {
     "plugin": "pyav",
     "in_pixel_format": "rgba",
     "filter_sequence": [
-        ("scale", "trunc(iw/2)*2:trunc(ih/2)*2"),
+        # Scale animation frames to the macro buffer size (16)
+        ("scale", "iw+gt(mod(iw,16), 0)*(16-mod(iw,16)):ih+gt(mod(ih,16), 0)*(16-mod(ih,16))"),
     ],
 }
 
@@ -452,7 +453,6 @@ class ExportImageHelper(QtCore.QObject):
 
     def _write_images(self, filenames, params):
         for filename, file_images in filenames:
-            print(filename, file_images)
             images_arrays = _image_to_frame_array(file_images, filename)
             try:
                 imageio.imwrite(filename, images_arrays, **params)

--- a/uwsift/view/export_image.py
+++ b/uwsift/view/export_image.py
@@ -30,7 +30,7 @@ PYAV_ANIMATION_PARAMS = {
     "plugin": "pyav",
     "in_pixel_format": "rgba",
     "filter_sequence": [
-        # Scale animation frames to the macro buffer size (16)
+        # Scale animation frames to the macro block size (16)
         ("scale", "iw+gt(mod(iw,16), 0)*(16-mod(iw,16)):ih+gt(mod(ih,16), 0)*(16-mod(ih,16))"),
     ],
 }

--- a/uwsift/view/export_image.py
+++ b/uwsift/view/export_image.py
@@ -232,7 +232,7 @@ class ExportImageHelper(QtCore.QObject):
         # give one extra pixel on the left to make sure letters
         # don't get cut off
         new_draw.text([1, orig_h], banner_text, fill="#ffffff", font=font)
-        txt_w, txt_h = new_draw.textsize("SIFT", font)
+        txt_w = new_draw.textlength("SIFT", font)
         new_draw.text([orig_w - txt_w, orig_h], "SIFT", fill="#ffffff", font=font)
         new_im.paste(im, (0, 0, orig_w, orig_h))
         return new_im

--- a/uwsift/view/export_image.py
+++ b/uwsift/view/export_image.py
@@ -287,6 +287,7 @@ class ExportImageHelper(QtCore.QObject):
 
         buf = io.BytesIO()
         fig.savefig(buf, format="png", bbox_inches="tight", dpi=self.sgm.main_canvas.dpi)
+        plt.close(fig)
         buf.seek(0)
         fig_im = Image.open(buf)
 
@@ -300,13 +301,12 @@ class ExportImageHelper(QtCore.QObject):
             for i in [im, fig_im]:
                 new_im.paste(i, (offset, 0))
                 offset += i.size[0]
-            return new_im
         else:
             new_im = Image.new(im.mode, (orig_w, orig_h + fig_h))
             for i in [im, fig_im]:
                 new_im.paste(i, (0, offset))
                 offset += i.size[1]
-            return new_im
+        return new_im
 
     def _create_filenames(self, uuids, base_filename):
         if not uuids or uuids[0] is None:

--- a/uwsift/view/scene_graph.py
+++ b/uwsift/view/scene_graph.py
@@ -15,19 +15,14 @@ As per http://api.vispy.org/en/latest/scene.html (abridged)
         3. add node instances to scene by making them children of canvas scene, or
            of nodes already in the scene
 
-REFERENCES
-http://api.vispy.org/en/latest/scene.html
-
-:author: R.K.Garcia <rayg@ssec.wisc.edu>
-:copyright: 2014 by University of Wisconsin Regents, see AUTHORS for more details
-:license: GPLv3, see LICENSE for more details
 """
+from __future__ import annotations
 
 import logging
 import os
 from enum import Enum
 from numbers import Number
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 from uuid import UUID
 
 import numpy as np
@@ -78,6 +73,10 @@ from uwsift.workspace.utils.metadata_utils import (
     get_point_style_by_name,
     map_point_style_to_marker_kwargs,
 )
+
+if TYPE_CHECKING:
+    import numpy.typing as npt
+
 
 LOG = logging.getLogger(__name__)
 DATA_DIR = get_package_data_dir()
@@ -313,9 +312,20 @@ class SceneGraphManager(QObject):
         self._setup_initial_canvas(center)
         self.pending_polygon = PendingPolygon(self.main_map)
 
-    def get_screenshot_array(self, frame_range=None):
-        """Get numpy arrays representing the current canvas."""
+    def get_screenshot_array(
+        self, frame_range: None | tuple[int, int] = None
+    ) -> list[tuple[str | UUID, npt.NDArray[np.uint8]]]:
+        """Get numpy arrays representing the current canvas.
 
+        Args:
+            frame_range: Start and end frame indexes to get arrays for.
+                Indexes are 0-based and both values (start and end) are
+                *inclusive*. Specifying ``(1, 3)`` means you'll get arrays
+                for frame at index 1 (the second frame), index 2, and index 3.
+                If not specified or ``None`` the current frame's data is
+                returned.
+
+        """
         if frame_range is None:
             self.main_canvas.on_draw(None)
             return [("", _screenshot())]

--- a/uwsift/view/scene_graph.py
+++ b/uwsift/view/scene_graph.py
@@ -326,13 +326,18 @@ class SceneGraphManager(QObject):
                 returned.
 
         """
-        if frame_range is None:
+        # Store current index to reset the view once we are done
+        # Or use it as the frame to screenshot if no frame range is specified
+        current_frame = self.animation_controller.get_current_frame_index()
+        if not current_frame:
+            # no data loaded
             self.main_canvas.on_draw(None)
             return [("", _screenshot())]
+        if frame_range is None:
+            # screenshot the current view
+            s = e = current_frame
         else:
             s, e = frame_range
-        # Store current index to reset the view once we are done
-        current_frame = self.animation_controller.get_current_frame_index()
 
         images = []
         for i in range(s, e + 1):

--- a/uwsift/view/scene_graph.py
+++ b/uwsift/view/scene_graph.py
@@ -329,7 +329,8 @@ class SceneGraphManager(QObject):
         # Store current index to reset the view once we are done
         # Or use it as the frame to screenshot if no frame range is specified
         current_frame = self.animation_controller.get_current_frame_index()
-        if not current_frame:
+        current_uuid = self.animation_controller.get_current_frame_uuid()
+        if not current_frame and not current_uuid:
             # no data loaded
             self.main_canvas.on_draw(None)
             return [("", _screenshot())]


### PR DESCRIPTION
Closes #372. This PR got really big really fast. Basically our tests should have caught an incompatibility between our code and updates in imageio. However, things were mocked so heavily in the tests that we weren't even actually using imageio. Things to know:

1. imageio offers a "v3" sub-package to use the newer version 3 of their API. This seemed like the easiest way to get things working while sort of future-proofing our usage of imageio.
2. The imageio-ffmpeg package is being deprecated in favor of a new pyav (`av` on PyPI and conda-forge...I don't know why). This is supposed to be faster, but it comes with some issues. I have to specify a codec (hardcoded to libx624) and specify the ffmpeg filter to scale images that are not power-of-2 sized so that they are. I've also forced this `pyav` plugin usage when saving animations so that we don't accidentally use the old plugin or have issues with other plugins being used.
3. Rewrote the export image tests...a lot.

This needs *heavy* testing.