### PR TITLE
Use curl from conda-forge with sftp support

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -72,7 +72,8 @@ jobs:
 
       - name: Install conda pack
         run: |
-          conda install conda-pack
+          conda install conda-pack curl
+          curl -V
 
       - name: Install uwsift
         run: |


### PR DESCRIPTION
It seems GitHub Actions images have dropped SFTP support in their curl builds.

@rayg-ssec can you do a `curl -V` and check if it lists `sftp` as one of the protocols it supports? Maybe check system curl versus homebrew or whatever you have. This PR tries switching to conda-forge so we'll see.