### PR TITLE
Fix MTG-LI filepattern filter and add FCI L2 BUFR/GRIB readers to list

### DIFF
--- a/uwsift/etc/SIFT/config/limit_available_readers.yaml
+++ b/uwsift/etc/SIFT/config/limit_available_readers.yaml
@@ -9,6 +9,8 @@ data_reading:
     - fci_l1c_nc
     - fci_l1c_iqt_fdhsi
     - fci_l2_nc
+    - fci_l2_bufr
+    - fci_l2_grib
     - li_l1b_nc
     - li_l1b_bck_nc_sift
     - li_l2_nc

--- a/uwsift/etc/SIFT/config/readers/fci_l2_bufr.yaml
+++ b/uwsift/etc/SIFT/config/readers/fci_l2_bufr.yaml
@@ -1,0 +1,5 @@
+data_reading:
+  fci_l2_bufr:
+    filter_patterns: ['{pflag}_{location_indicator},{data_designator},MTI{spacecraft_id:1d}+FCI-2-{type}-{subtype}-{coverage}-{subsetting}-{component1}-{component2}-{component3}-{purpose}-BUFR_{oflag}_{originator}_{processing_time:%Y%m%d%H%M%S}_{facility_or_tool}_{environment}_{start_time:%Y%m%d%H%M%S}_{end_time:%Y%m%d%H%M%S}_{processing_mode}_{special_compression}_{disposition_mode}_{repeat_cycle_in_day:>04d}_{count_in_repeat_cycle:>04d}.bin']
+    reader_kwargs:
+       with_area_definition: True

--- a/uwsift/etc/SIFT/config/readers/fci_l2_grib.yaml
+++ b/uwsift/etc/SIFT/config/readers/fci_l2_grib.yaml
@@ -1,4 +1,3 @@
 data_reading:
   fci_l2_grib:
     filter_patterns: ['{pflag}_{location_indicator},{data_designator},MTI{spacecraft_id:1d}+FCI-2-{type}-{subtype}-{coverage}-{subsetting}-{component1}-{component2}-{component3}-{purpose}-GRIB2_{oflag}_{originator}_{processing_time:%Y%m%d%H%M%S}_{facility_or_tool}_{environment}_{start_time:%Y%m%d%H%M%S}_{end_time:%Y%m%d%H%M%S}_{processing_mode}_{special_compression}_{disposition_mode}_{repeat_cycle_in_day:>04d}_{count_in_repeat_cycle:>04d}.bin']
-

--- a/uwsift/etc/SIFT/config/readers/fci_l2_grib.yaml
+++ b/uwsift/etc/SIFT/config/readers/fci_l2_grib.yaml
@@ -1,0 +1,4 @@
+data_reading:
+  fci_l2_grib:
+    filter_patterns: ['{pflag}_{location_indicator},{data_designator},MTI{spacecraft_id:1d}+FCI-2-{type}-{subtype}-{coverage}-{subsetting}-{component1}-{component2}-{component3}-{purpose}-GRIB2_{oflag}_{originator}_{processing_time:%Y%m%d%H%M%S}_{facility_or_tool}_{environment}_{start_time:%Y%m%d%H%M%S}_{end_time:%Y%m%d%H%M%S}_{processing_mode}_{special_compression}_{disposition_mode}_{repeat_cycle_in_day:>04d}_{count_in_repeat_cycle:>04d}.bin']
+

--- a/uwsift/etc/SIFT/config/readers/li_l1b_nc.yaml
+++ b/uwsift/etc/SIFT/config/readers/li_l1b_nc.yaml
@@ -3,7 +3,7 @@ data_reading:
     group_keys: ['start_time']
     filter_patterns:
       [
-        '{pflag}_{location_indicator},{data_designator},MTGI{spacecraft_id}+LI-1B-{type}--{subtype}--{component1}-{component2}-{component3}-{purpose}-{format}_{oflag}_{originator}_{processing_time:%Y%m%d%H%M%S}_{facility_or_tool}_{environment}_{start_time:%Y%m%d%H%M%S}_{end_time:%Y%m%d%H%M%S}_{processing_mode}_{special_compression}_{disposition_mode}_{repeat_cycle_in_day:>04d}_{count_in_repeat_cycle:>04d}.nc'
+        '{pflag}_{location_indicator},{data_designator},{spacecraft_id}+LI-1B-{type}--{subtype}--{component1}-{component2}-{component3}-{purpose}-{format}_{oflag}_{originator}_{processing_time:%Y%m%d%H%M%S}_{facility_or_tool}_{environment}_{start_time:%Y%m%d%H%M%S}_{end_time:%Y%m%d%H%M%S}_{processing_mode}_{special_compression}_{disposition_mode}_{repeat_cycle_in_day:>04d}_{count_in_repeat_cycle:>04d}.nc'
       ]
     kind: 'DYNAMIC'
     style_attributes:

--- a/uwsift/etc/SIFT/config/readers/li_l2_nc.yaml
+++ b/uwsift/etc/SIFT/config/readers/li_l2_nc.yaml
@@ -3,7 +3,7 @@ data_reading:
     group_keys: ['start_time']
     filter_patterns:
       [
-        '{pflag}_{location_indicator},{data_designator},MTGI{spacecraft_id}+LI-2-{type}--{subtype}--{component1}-{component2}-{component3}-{purpose}-{format}_{oflag}_{originator}_{processing_time:%Y%m%d%H%M%S}_{facility_or_tool}_{environment}_{start_time:%Y%m%d%H%M%S}_{end_time:%Y%m%d%H%M%S}_{processing_mode}_{special_compression}_{disposition_mode}_{repeat_cycle_in_day:>04d}_{count_in_repeat_cycle:>04d}.nc'
+        '{pflag}_{location_indicator},{data_designator},{spacecraft_id}+LI-2-{type}--{subtype}--{component1}-{component2}-{component3}-{purpose}-{format}_{oflag}_{originator}_{processing_time:%Y%m%d%H%M%S}_{facility_or_tool}_{environment}_{start_time:%Y%m%d%H%M%S}_{end_time:%Y%m%d%H%M%S}_{processing_mode}_{special_compression}_{disposition_mode}_{repeat_cycle_in_day:>04d}_{count_in_repeat_cycle:>04d}.nc'
       ]
     kind: 'DYNAMIC'
     style_attributes:


### PR DESCRIPTION
This PR fixes an issue in the filepattern filter for LI data, and adds FCI L2 BUFR/GRIB readers to the list of readers with the according config file.