### PR TITLE
Fix pre-commit with types-setuptools and limit python to 3.11 due to ecmwflibs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -128,7 +128,6 @@ jobs:
           --no-deps --upgrade \
           git+https://github.com/dask/dask \
           git+https://github.com/dask/distributed \
-          git+https://github.com/zarr-developers/zarr \
           git+https://github.com/Unidata/cftime \
           git+https://github.com/mapbox/rasterio \
           git+https://github.com/pydata/bottleneck \

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
       - id: mypy
         additional_dependencies:
           - types-docutils
-          - types-pkg-resources
+          - types-setuptools
           - types-PyYAML
           - types-requests
           - types-python-dateutil

--- a/continuous_integration/environment.yaml
+++ b/continuous_integration/environment.yaml
@@ -2,6 +2,8 @@ name: test-environment
 channels:
   - conda-forge
 dependencies:
+  # limiting python due to ecmwflibs
+  - python<=3.11
   - appdirs
   - defusedxml
   - Cython

--- a/continuous_integration/rtd_environment.yaml
+++ b/continuous_integration/rtd_environment.yaml
@@ -2,6 +2,8 @@ name: test-environment
 channels:
   - conda-forge
 dependencies:
+  # limiting python due to ecmwflibs
+  - python<=3.11
   - appdirs
   - defusedxml
   - Cython

--- a/setup.py
+++ b/setup.py
@@ -226,7 +226,7 @@ setup(
         "cfgrib",
     ],
     tests_requires=["pytest", "pytest-qt", "pytest-mock"],
-    python_requires=">=3.8",
+    python_requires=">=3.8, <=3.11",  # limiting to 3.11 until ecmwflibs is not available for 3.12
     extras_require=extras_require,
     packages=find_packages(),
     entry_points={


### PR DESCRIPTION
This PR fixes the pre-commit dependencies to move away from the deprecated/yanked `types-pkg-resources` to `types-setuptools`, as suggested in e.g. https://pypi.org/project/types-pkg-resources/ . This was making the pre-commit run fail.

On top, it limits python to 3.11, since there are currently no wheels for `ecmwflibs` for 3.12 and it is preventing the builds to resolve the environments.