### PR TITLE
Update CI test python versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
         with:
           miniforge-variant: Mambaforge
           miniforge-version: latest
-          python-version: "3.10"
+          python-version: "3.11"
           use-mamba: true
           environment-file: continuous_integration/environment.yaml
           activate-environment: test-environment
@@ -73,10 +73,10 @@ jobs:
         # XXX: We don't currently have OpenGL installation on other platforms
         #os: ["windows-latest", "ubuntu-latest", "macos-latest"]
         os: ["ubuntu-latest"]
-        python-version: ["3.8", "3.10"]
+        python-version: ["3.9", "3.11"]
         experimental: [false]
         include:
-          - python-version: "3.10"
+          - python-version: "3.11"
             os: "ubuntu-latest"
             experimental: true
 


### PR DESCRIPTION
This PR updates the CI tests to run on 3.9 and 3.11 instead of 3.8 and 3.10. Since we currently bundle the 3.11 version, it makes sense to test it as well. 