### PR TITLE
Fix resolution formatting for numpy floats

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ also be found on GitHub: https://github.com/ssec/sift/wiki
 Developer and configuration documentation can be found on
 https://sift.readthedocs.io/en/latest/.
 
+The recording of a SIFT Short Course organised by EUMETSAT can be found [here](https://classroom.eumetsat.int/course/view.php?id=478).
+
 ## What's new in SIFT 2.0
 
 Many new features have been added starting from the version 2.0 of SIFT, including:
@@ -44,6 +46,10 @@ Many new features have been added starting from the version 2.0 of SIFT, includi
 - an automatic update/monitoring mode
 - partial redesign of the UI/UX
 - ... many more small but useful features!
+
+Note that SIFT v2.0 is still in Beta phase. Until a full release is reached, the
+packaged builds are available in the [experimental ftp folder](https://bin.ssec.wisc.edu/pub/sift/dist/experimental/).
+See the Installatio section below for more information.
 
 ## History
 

--- a/doc/source/dev_guide/contributing.rst
+++ b/doc/source/dev_guide/contributing.rst
@@ -8,6 +8,10 @@ codebase. The documentation below is meant to point you in the right direction
 on how you can contribute and what the SIFT team might expect for contributions
 we receive.
 
+If you'd like to chat with the developers about SIFT programming and design
+questions you can do so on our `Gitter Chat <https://gitter.im/ssec/sift>`_ or
+through GitHub issues (see below).
+
 Development Team
 ----------------
 
@@ -20,9 +24,6 @@ although these two teams may have differing goals, SIFT is kept in a flexible
 state that allows it to be used for forecast training, Cal/Val operations for
 instruments, or many other use cases.
 
-If you'd like to chat with the developers about SIFT programming and design
-questions you can do so on our `Gitter Chat <https://gitter.im/ssec/sift>`_ or
-through GitHub issues (see below).
 
 SSEC
 ^^^^

--- a/uwsift/tests/util/test_common.py
+++ b/uwsift/tests/util/test_common.py
@@ -1,0 +1,25 @@
+from decimal import Decimal
+
+import numpy as np
+import pytest
+
+from uwsift.util.common import format_resolution
+
+
+@pytest.mark.parametrize(
+    "resolution, expected",
+    [
+        (999, "999 m"),  # Test with a value less than 1000 meters
+        (1000, "1.0 km"),  # Test with exactly 1000 meters
+        (1500, "1.5 km"),  # Test with a value greater than 1000 meters
+        (25000, "25.0 km"),  # Test with a large value
+        (1, "1 m"),  # Test with a value close to 1 meter
+        (1234.56, "1.2 km"),  # Test with a float value
+        (np.float32(500), "500 m"),  # Test with a numpy numeric value less than 1000 meters
+        (np.float64(1500), "1.5 km"),  # Test with a numpy numeric value greater than 1000 meters
+        (Decimal("750.0"), "750 m"),  # Test with a Decimal value less than 1000 meters
+        (Decimal("1250.0"), "1.2 km"),  # Test with a Decimal value greater than 1000 meters
+    ],
+)
+def test_format_resolution(resolution, expected):
+    assert format_resolution(resolution) == expected

--- a/uwsift/util/common.py
+++ b/uwsift/util/common.py
@@ -305,6 +305,9 @@ def format_resolution(resolution: float) -> str:
     """Return string representing the given resolution (interpreted in meters)
     in the unit km for values greater than 1 km, otherwise in m, including the
     unit symbol."""
+    if isinstance(resolution, np.number):
+        # Decimal requires a python numeric value
+        resolution = resolution.item()
     resolution_dec = Decimal(resolution)
     if resolution_dec < 1000:
         return str(resolution_dec.quantize(Decimal("1."))) + " m"


### PR DESCRIPTION
This PR fixes a bug that was causing the layer details panel to be empty in the new builds (probably an old deprecation now failing?). The cause was the resolution formatting failing since `Decimal` does not accept numpy floats.

On a side, it makes some updates to the Readme and docs