### PR TITLE
Remove mambaforge usages and update configs to remove EUM-internal readers

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,12 +41,11 @@ jobs:
       - name: Setup Conda Environment
         uses: conda-incubator/setup-miniconda@v3
         with:
-          miniforge-variant: Mambaforge
           miniforge-version: latest
           python-version: "3.11"
-          use-mamba: true
           environment-file: continuous_integration/environment.yaml
           activate-environment: test-environment
+          channels: conda-forge
 
       - name: Install SIFT
         shell: bash -l {0}
@@ -106,12 +105,11 @@ jobs:
       - name: Setup Conda Environment
         uses: conda-incubator/setup-miniconda@v3
         with:
-          miniforge-variant: Mambaforge
           miniforge-version: latest
-          use-mamba: true
           python-version: ${{ matrix.python-version }}
           environment-file: continuous_integration/environment.yaml
           activate-environment: test-environment
+          channels: conda-forge
 
       - name: Install unstable dependencies
         if: matrix.experimental == true

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Create sdist
         shell: bash -l {0}
-        run: python3 -m pip install build; python -m build
+        run: python -m pip install --break-system-packages build; python -m build
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -64,11 +64,10 @@ jobs:
       - name: Setup Conda Environment
         uses: conda-incubator/setup-miniconda@v3
         with:
-          miniforge-variant: Mambaforge
           miniforge-version: latest
-          use-mamba: true
           environment-file: continuous_integration/environment.yaml
           activate-environment: test-environment
+          channels: conda-forge
 
       - name: Install conda pack
         run: |

--- a/uwsift/etc/SIFT/config/area_definitions.yaml
+++ b/uwsift/etc/SIFT/config/area_definitions.yaml
@@ -1,14 +1,14 @@
 area_definitions:
 
+  MTG FCI FDSS 1km: mtg_fci_fdss_1km
+  MTG FCI FDSS 2km: mtg_fci_fdss_2km
+  MTG FCI FDSS 500m: mtg_fci_fdss_500m
   MSG SEVIRI FES 3km: msg_seviri_fes_3km
   MSG SEVIRI FES 1km: msg_seviri_fes_1km
   MSG SEVIRI RSS 3km: msg_seviri_rss_3km
   MSG SEVIRI RSS 1km: msg_seviri_rss_1km
   MSG SEVIRI IODC 3km: msg_seviri_iodc_3km
   MSG SEVIRI IODC 1km: msg_seviri_iodc_1km
-  MTG FCI FDSS 500m: mtg_fci_fdss_500m
-  MTG FCI FDSS 1km: mtg_fci_fdss_1km
-  MTG FCI FDSS 2km: mtg_fci_fdss_2km
   GOES-East ABI F 500m: goes_east_abi_f_500m
   GOES-East ABI F 1km: goes_east_abi_f_1km
   GOES-East ABI F 2km: goes_east_abi_f_2km

--- a/uwsift/etc/SIFT/config/limit_available_readers.yaml
+++ b/uwsift/etc/SIFT/config/limit_available_readers.yaml
@@ -3,18 +3,12 @@ data_reading:
   readers:
     - abi_l1b
     - abi_l2_nc
-    - fci_l1_cat_lmk_loc
-    - fci_l1_geoobs_lmk_loc
-    - fci_l1_geoobs_lmk_nav_err
     - fci_l1c_nc
-    - fci_l1c_iqt_fdhsi
     - fci_l2_nc
     - fci_l2_bufr
     - fci_l2_grib
     - li_l1b_nc
-    - li_l1b_bck_nc_sift
     - li_l2_nc
-    - li_l2_a_nc_sift
     - seviri_l1b_hrit
     - seviri_l1b_native
     - seviri_l2_binary

--- a/uwsift/etc/SIFT/config/readers/fci_l1_cat_lmk_loc.yaml
+++ b/uwsift/etc/SIFT/config/readers/fci_l1_cat_lmk_loc.yaml
@@ -1,7 +1,0 @@
-data_reading:
-  fci_l1_cat_lmk_loc:
-    group_keys: ['creation_time', 'free_format']
-    filter_patterns: ['IQT-I__CFG+MTP-CAT-LMK_{free_description}_{creation_time:%Y%m%d%H%M%S}_{free_format}.xml']
-    kind: 'POINTS'
-    style_attributes:
-      fill: 'catalogue_landmark_locations'

--- a/uwsift/etc/SIFT/config/readers/fci_l1_geoobs_lmk_loc.yaml
+++ b/uwsift/etc/SIFT/config/readers/fci_l1_geoobs_lmk_loc.yaml
@@ -1,5 +1,0 @@
-data_reading:
-  fci_l1_geoobs_lmk_loc:
-    group_keys: ['data_source', 'start_time']
-    filter_patterns: ['{pflag}_{location_indicator},{data_designator},MTI{spacecraft_id:1d}+{data_source}-{processing_level}-DPP-GEOOBS-{coverage}-{subsetting}-{component1}-{component2}-{component3}-{purpose}-{format}_{oflag}_{originator}_{processing_time:%Y%m%d%H%M%S}_{facility_or_tool}_{environment}_{start_time:%Y%m%d%H%M%S}_{end_time:%Y%m%d%H%M%S}_{processing_mode}_{special_compression}_{disposition_mode}_{repeat_cycle_in_day:>04d}_{count_in_repeat_cycle:>04d}.nc']
-    kind: 'POINTS'

--- a/uwsift/etc/SIFT/config/readers/fci_l1_geoobs_lmk_nav_err.yaml
+++ b/uwsift/etc/SIFT/config/readers/fci_l1_geoobs_lmk_nav_err.yaml
@@ -1,6 +1,0 @@
-data_reading:
-  fci_l1_geoobs_lmk_nav_err:
-    group_keys: ['data_source', 'start_time']
-    filter_patterns: ['{pflag}_{location_indicator},{data_designator},MTI{spacecraft_id:1d}+{data_source}-{processing_level}-DPP-GEOOBS-{coverage}-{subsetting}-{component1}-{component2}-{component3}-{purpose}-{format}_{oflag}_{originator}_{processing_time:%Y%m%d%H%M%S}_{facility_or_tool}_{environment}_{start_time:%Y%m%d%H%M%S}_{end_time:%Y%m%d%H%M%S}_{processing_mode}_{special_compression}_{disposition_mode}_{repeat_cycle_in_day:>04d}_{count_in_repeat_cycle:>04d}.nc']
-    kind: 'LINES'
-    coordinates_end: ['longitude_reference', 'latitude_reference']

--- a/uwsift/etc/SIFT/config/readers/fci_l1c_iqt_fdhsi.yaml
+++ b/uwsift/etc/SIFT/config/readers/fci_l1c_iqt_fdhsi.yaml
@@ -1,9 +1,0 @@
-data_reading:
-  fci_l1c_iqt_fdhsi:
-    group_keys: ['repeat_cycle_in_day']
-    filter_patterns: ['{pflag}_{location_indicator},{data_designator},MTI{spacecraft_id:1d}+FCI-1C-RRAD-{subtype}-{coverage}-{subsetting}-{component1}-BODY-{component3}-{purpose}-{format}_{oflag}_{originator}_{processing_time:%Y%m%d%H%M%S}_{facility_or_tool}_{environment}_{start_time:%Y%m%d%H%M%S}_{end_time:%Y%m%d%H%M%S}_{processing_mode}_{special_compression}_{disposition_mode}_{repeat_cycle_in_day:>04d}_{count_in_repeat_cycle:>04d}.nc']
-
-    grid:
-      origin: "SW"
-      first_index_x: 1
-      first_index_y: 1

--- a/uwsift/etc/SIFT/config/readers/lsasaf_l2_frppixel_hdf.yaml
+++ b/uwsift/etc/SIFT/config/readers/lsasaf_l2_frppixel_hdf.yaml
@@ -1,8 +1,0 @@
-data_reading:
-  lsasaf_l2_frppixel_hdf:
-    group_keys: ['start_time']
-    filter_patterns:
-      - 'HDF5_LSASAF_MSG_FRP-PIXEL-ListProduct_MSG-Disk_{start_time:%Y%m%d%H%M}'
-    kind: 'POINTS'
-    style_attributes:
-      fill: ['FRP']

--- a/uwsift/etc/SIFT/config/readers/modis_l2_fire_hdf.yaml
+++ b/uwsift/etc/SIFT/config/readers/modis_l2_fire_hdf.yaml
@@ -1,8 +1,0 @@
-data_reading:
-  modis_l2_fire_hdf:
-    group_keys: ['acquisition_time']
-    filter_patterns:
-      - 'M{platform_indicator:1s}D14.A{acquisition_time:%Y%j.%H%M}.{collection:03d}.{production_time:%Y%j%H%M%S}.hdf'
-    kind: 'POINTS'
-    style_attributes:
-      fill: ['FP_power']

--- a/uwsift/etc/SIFT/config/readers/viirs_l2_fire_nc.yaml
+++ b/uwsift/etc/SIFT/config/readers/viirs_l2_fire_nc.yaml
@@ -1,8 +1,0 @@
-data_reading:
-  viirs_l2_fire_nc:
-    group_keys: ['start_time']
-    filter_patterns:
-      - 'V{platform_shortname:2s}14IMG.A{start_time:%Y%j.%H%M}.{collection_number:3d}.{creation_time:%Y%j%H%M%S}{creator}.nc'
-    kind: 'POINTS'
-    style_attributes:
-      fill: ['FP_power']


### PR DESCRIPTION
This PR updates some configs to get rid of EUM-internal/specific settings. It also removes Mambaforge usages due to pending deprecations.