### PR TITLE
Add support for Python 3.12

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -227,7 +227,7 @@ setup(
         "cfgrib",
     ],
     tests_requires=["pytest", "pytest-qt", "pytest-mock"],
-    python_requires=">=3.8, <=3.11",  # limiting to 3.11 until ecmwflibs is not available for 3.12
+    python_requires=">=3.8, <=3.12",  # limiting to 3.12 until ecmwflibs is available for 3.13
     extras_require=extras_require,
     packages=find_packages(),
     entry_points={


### PR DESCRIPTION
On 2024-10-02, a ecmwflibs version for Python 3.12 appears on conda-forge.  Edit the supported Python versions in setup.py accordingly.