### PR TITLE
Remove deprecated PermissionError from psutil in favour of builtin

### DIFF
--- a/uwsift/util/disk_management.py
+++ b/uwsift/util/disk_management.py
@@ -3,7 +3,7 @@ import atexit
 from time import sleep
 from typing import Dict, List, Optional
 
-from psutil import NoSuchProcess, PermissionError, Process, process_iter
+from psutil import NoSuchProcess, Process, process_iter
 
 
 class DiskManagement:


### PR DESCRIPTION
This PR removes the import of the deprecated PermissionError. This was also causing a Warning/Error in readthedocs.