### PR TITLE
Issue #333: Fixing color limit inversion support for image export

### DIFF
--- a/uwsift/view/export_image.py
+++ b/uwsift/view/export_image.py
@@ -257,7 +257,11 @@ class ExportImageHelper(QtCore.QObject):
 
         cmap = mpl.colors.ListedColormap(colors)
         vmin, vmax = self.model.get_dataset_presentation_by_uuid(u).climits
-        norm = mpl.colors.Normalize(vmin=vmin, vmax=vmax)
+        # Issue #333: need to take into consideration that the vmin/vmax order might be
+        # inverted here:
+        mini = min(vmin, vmax)
+        maxi = max(vmin, vmax)
+        norm = mpl.colors.Normalize(vmin=mini, vmax=maxi)
         cbar = mpl.colorbar.ColorbarBase(ax, cmap=cmap, norm=norm, orientation=mode)
 
         ticks = [
@@ -266,7 +270,7 @@ class ExportImageHelper(QtCore.QObject):
                     self.model.get_dataset_by_uuid(u).info.get(Info.UNIT_CONVERSION)[1](t)
                 )
             )
-            for t in np.linspace(vmin, vmax, NUM_TICKS)
+            for t in np.linspace(mini, maxi, NUM_TICKS)
         ]
         cbar.set_ticks(np.linspace(vmin, vmax, NUM_TICKS))
         cbar.set_ticklabels(ticks)

--- a/uwsift/view/layer_details.py
+++ b/uwsift/view/layer_details.py
@@ -164,7 +164,11 @@ class SingleLayerInfoPane(QtWidgets.QWidget):
         model.change_colormap_for_layer(self._current_selected_layer.uuid, self._current_cmap)
 
     def _create_slider_value(self, channel_val):
-        return int((channel_val - self._valid_min) / (self._valid_max - self._valid_min) * self._slider_steps)
+        if self._valid_max == self._valid_min:
+            return 0
+        mini = min(self._valid_min, self._valid_max)
+        maxi = max(self._valid_min, self._valid_max)
+        return int((channel_val - mini) / (maxi - mini) * self._slider_steps)
 
     def _determine_display_value_for_clims(self):
         try:
@@ -264,7 +268,11 @@ class SingleLayerInfoPane(QtWidgets.QWidget):
         return wavelength_str
 
     def _get_slider_value(self, slider_val):
-        return (slider_val / self._slider_steps) * (self._valid_max - self._valid_min) + self._valid_min
+        if self._valid_max == self._valid_min:
+            return self._valid_min
+        mini = min(self._valid_min, self._valid_max)
+        maxi = max(self._valid_min, self._valid_max)
+        return (slider_val / self._slider_steps) * (maxi - mini) + mini
 
     def _init_cmap_combo(self):
         # FIXME: We should do this by colormap category
@@ -426,15 +434,22 @@ class SingleLayerInfoPane(QtWidgets.QWidget):
     def _update_gamma(self):
         self._details_pane_ui.gammaSpinBox.setValue(self._current_selected_layer.presentation.gamma)
 
+    def _update_spin_box(self, spinbox, cur_val):
+        # Issue #333: need to take into account here that valid_min/valid_max might be inverted,
+        # so the spinbox range should be set with the actual min/max values:
+        conv = self._current_selected_layer.info[Info.UNIT_CONVERSION]
+        vmin = min(conv[1](self._valid_min), conv[1](self._valid_max))
+        vmax = max(conv[1](self._valid_min), conv[1](self._valid_max))
+        spinbox.setRange(vmin, vmax)
+        spinbox.setValue(conv[1](cur_val))
+
     def _update_vmin(self):
         current_vmin = self._current_selected_layer.presentation.climits[0]
         self._details_pane_ui.vmin_slider.setRange(0, self._slider_steps)
         slider_val = self._create_slider_value(current_vmin)
         self._details_pane_ui.vmin_slider.setSliderPosition(max(slider_val, 0))
 
-        conv = self._current_selected_layer.info[Info.UNIT_CONVERSION]
-        self._details_pane_ui.vmin_spinbox.setRange(conv[1](self._valid_min), conv[1](self._valid_max))
-        self._details_pane_ui.vmin_spinbox.setValue(conv[1](current_vmin))
+        self._update_spin_box(self._details_pane_ui.vmin_spinbox, current_vmin)
 
     def _update_vmax(self):
         current_vmax = self._current_selected_layer.presentation.climits[1]
@@ -443,6 +458,4 @@ class SingleLayerInfoPane(QtWidgets.QWidget):
         slider_val = self._create_slider_value(current_vmax)
         self._details_pane_ui.vmax_slider.setSliderPosition(min(slider_val, 32767))
 
-        conv = self._current_selected_layer.info[Info.UNIT_CONVERSION]
-        self._details_pane_ui.vmax_spinbox.setRange(conv[1](self._valid_min), conv[1](self._valid_max))
-        self._details_pane_ui.vmax_spinbox.setValue(conv[1](current_vmax))
+        self._update_spin_box(self._details_pane_ui.vmax_spinbox, current_vmax)


### PR DESCRIPTION
Hi @ameraner , @strandgren , @sjoro ,

This PR provides the required fixes for issue #333: 

To support the "color bar inversion" while generating the exported image we simply need to always map our color limit min/max values appropriately (ie. irrespectively of the name "vmax/vmin" that we use for those values): this part of the fix is included in the export_image.py file.

Now, on a similar not, in the layer_details.py conversions between QT physical units and dataset value units were not always properly taking into account that what we call "valid_max"/"valid_min" could also be inverted. So I introduced a few changes in that file too. 

=> Overall, the image export feature now seems to work as expected for me with those changes. But of course, please let me know if you think there is anything we need to discuss/change before the PR can be accepted. Thanks 🙏!