### PR TITLE
Fix unnecessary global var to please flake8

### DIFF
--- a/uwsift/workspace/metadatabase.py
+++ b/uwsift/workspace/metadatabase.py
@@ -798,7 +798,6 @@ class Metadatabase(object):
 
     def __init__(self, uri=None, **kwargs):
         self.session_nesting = defaultdict(int)
-        global _MDB
         if _MDB is not None:
             raise AssertionError("Metadatabase is a singleton and already exists")
         self._MDB = self


### PR DESCRIPTION
With the new flake8 version the CI is now failing due to an unnecessary global var definition:
![image](https://github.com/user-attachments/assets/15f7fcb4-95a0-4f84-9b60-149c8195d276)
This PR fixes the issue.