### PR TITLE
New feature 416

### DIFF
--- a/uwsift/__main__.py
+++ b/uwsift/__main__.py
@@ -919,6 +919,8 @@ class Main(QtWidgets.QMainWindow):
         time_manager.qml_backend = QmlBackend()
         time_manager.qml_backend.didJumpInTimeline.connect(self.scene_manager.animation_controller.jump)
         time_manager.qml_backend.didChangeTimebase.connect(time_manager.on_timebase_change)
+        self.ui.treeView.layerSelectionChangedIndex.connect(time_manager.qml_backend.select_layer_index)
+
         # TODO(mk): refactor all QML related objects as belonging to TimeManager's QMLBackend
         #           instance -> communication between TimeManager and QMLBackend via Signal/Slot?
         time_manager.qml_backend.qml_layer_manager = time_manager.qml_layer_manager

--- a/uwsift/control/qml_utils.py
+++ b/uwsift/control/qml_utils.py
@@ -331,3 +331,6 @@ class QmlBackend(QObject):
             data_layer_index = self.qml_layer_manager.get_convenience_function(conv_func_name)()
             if data_layer_index >= 0:
                 self.didChangeTimebase.emit(data_layer_index)
+
+    def select_layer_index(self, idx):
+        self.didChangeTimebase.emit(idx)

--- a/uwsift/model/layer_model.py
+++ b/uwsift/model/layer_model.py
@@ -51,6 +51,7 @@ class LayerModel(QAbstractItemModel):
     didChangeRecipeLayerNames = pyqtSignal(str)
 
     didUpdateLayers = pyqtSignal()
+    didChangeCurrentLayer = pyqtSignal(UUID)
     didReorderLayers = pyqtSignal(list)
     didFinishActivateProductDatasets = pyqtSignal()
 
@@ -351,6 +352,7 @@ class LayerModel(QAbstractItemModel):
             else:
                 raise NotImplementedError(f"Managing datasets of kind {product_dataset.kind}" f" not (yet) supported.")
 
+            self.didChangeCurrentLayer.emit(layer.uuid)
             self.didUpdateLayers.emit()
         self._update_dependent_recipe_layers(layer)
 
@@ -716,7 +718,7 @@ class LayerModel(QAbstractItemModel):
                 self.change_color_limits_for_layer(recipe_layer.uuid, climits)
             elif not any(input_layers):
                 self.change_color_limits_for_layer(recipe_layer.uuid, INVALID_COLOR_LIMITS)
-
+        self.didChangeCurrentLayer.emit(recipe_layer.uuid)
         self.didUpdateLayers.emit()
 
     def _check_recipe_layer_sched_times_to_update(

--- a/uwsift/model/layer_model.py
+++ b/uwsift/model/layer_model.py
@@ -146,6 +146,9 @@ class LayerModel(QAbstractItemModel):
     def get_dynamic_layers(self):
         return [layer for layer in self.layers if layer.dynamic]
 
+    def get_dynamic_layer_id(self, layer: LayerItem):
+        return next((i for i, layer_ in enumerate(self.get_dynamic_layers()) if layer_.uuid == layer.uuid), -1)
+
     def data(self, index: QModelIndex, role: Optional[int] = None):
         if not index.isValid():
             return None

--- a/uwsift/model/time_manager.py
+++ b/uwsift/model/time_manager.py
@@ -70,6 +70,7 @@ class TimeManager(QObject):
         layer_model.didUpdateLayers.connect(self.sync_to_time_transformer)
         layer_model.didChangeRecipeLayerNames.connect(self.update_qml_layer_model)
         layer_model.didReorderLayers.connect(self._update_layer_order)
+        layer_model.didChangeCurrentLayer.connect(self.change_current_timebase_uuid)
 
         self.didMatchTimes.connect(self._layer_model.on_didMatchTimes)
 
@@ -255,3 +256,8 @@ class TimeManager(QObject):
         self._time_transformer.change_timebase(layer)
         self.update_qml_timeline(layer)
         self.sync_to_time_transformer()
+
+    def change_current_timebase_uuid(self, uuid):
+        layer = self._layer_model.get_layer_by_uuid(uuid)
+        if layer.dynamic:
+            self.current_timebase_uuid = uuid

--- a/uwsift/view/layer_tree_view.py
+++ b/uwsift/view/layer_tree_view.py
@@ -16,6 +16,7 @@ LOG = logging.getLogger(__name__)
 
 class LayerTreeView(QTreeView):
     layerSelectionChanged = pyqtSignal(tuple)
+    layerSelectionChangedIndex = pyqtSignal(int)
     selectedLayerForProbeChanged = pyqtSignal(str)
 
     def __init__(self, *args, **kwargs):
@@ -128,6 +129,10 @@ class LayerTreeView(QTreeView):
         if len(self.model().layers) > 0:
             selected_layer: tuple = (self.model().layers[current.row()],)
             self.layerSelectionChanged.emit(selected_layer)
+            dynamic_layer_id = self.model().get_dynamic_layer_id(selected_layer[0])
+            if dynamic_layer_id != -1:
+                self.layerSelectionChangedIndex.emit(dynamic_layer_id)
+
             self.selectedLayerForProbeChanged.emit(DEFAULT_POINT_PROBE)
 
     def begin_layers_removal(self, *args, **kwargs):


### PR DESCRIPTION
This pull request refers to the implementation of a new feature for linking the Layer Manager and the Driving Layer box  https://github.com/ssec/sift/issues/416 :

1. They are initially connected (the same layer is shown in both by default)
2. When a layer is selected in the Layer Manager, that same layer becomes selected in the Driving Layer box. 
3. This functionality also works when adding new layers to the Layer Manager, as well as when adding Algebraic and Composite layers (once they become dynamic, of course).

The other way around is not applied, as stated in the feature request itself, in order to preserve flexibility. That is, when a layer is selected in the Driving Layer box, it is not automatically selected in the Layer Manager.